### PR TITLE
fix: encode time in logs with ISO8601TimeEncoder

### DIFF
--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -7,6 +7,8 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -41,6 +43,7 @@ func main() {
 	flag.StringVar(&ignoreNamespace, "ignore-namespace", "kuik-system", "The address the probe endpoint binds to.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
see https://github.com/kubernetes-sigs/controller-runtime/issues/2173