### PR TITLE
Rename helm resources

### DIFF
--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -18,6 +18,7 @@ import (
 
 	kuikenixiov1 "github.com/enix/kube-image-keeper/api/v1"
 	"github.com/enix/kube-image-keeper/controllers"
+	"github.com/enix/kube-image-keeper/internal/registry"
 	"github.com/enix/kube-image-keeper/internal/scheme"
 	//+kubebuilder:scaffold:imports
 )
@@ -41,6 +42,7 @@ func main() {
 	flag.UintVar(&expiryDelay, "expiry-delay", 30, "The delay in days before deleting an unused CachedImage.")
 	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port where the proxy is listening on this machine.")
 	flag.StringVar(&ignoreNamespace, "ignore-namespace", "kuik-system", "The address the probe endpoint binds to.")
+	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kuik-registry:5000", "The address of the registry where cached images are stored.")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,

--- a/helm/kube-image-keeper/templates/_helpers.tpl
+++ b/helm/kube-image-keeper/templates/_helpers.tpl
@@ -14,11 +14,12 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- $name := default "kuik" .Values.nameOverride }}
+{{- $releaseName := .Release.Name | replace .Chart.Name "kuik" }}
+{{- if contains $name $releaseName }}
+{{- $releaseName | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/kube-image-keeper/templates/_helpers.tpl
+++ b/helm/kube-image-keeper/templates/_helpers.tpl
@@ -108,5 +108,5 @@ app.kubernetes.io/component: garbage-collection
 Create the name of the service account to use
 */}}
 {{- define "kube-image-keeper.serviceAccountName" -}}
-{{- default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}
+{{- default (printf "%s-%s" (include "kube-image-keeper.fullname" .) "controllers") .Values.serviceAccount.name }}
 {{- end }}

--- a/helm/kube-image-keeper/templates/clusterrole.yaml
+++ b/helm/kube-image-keeper/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}
 rules:
   - apiGroups:
     - ""
@@ -87,7 +87,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}-leader-election
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
 rules:
   - apiGroups:
     - ""

--- a/helm/kube-image-keeper/templates/clusterrolebinding.yaml
+++ b/helm/kube-image-keeper/templates/clusterrolebinding.yaml
@@ -2,10 +2,10 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}
 roleRef:
   kind: ClusterRole
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -15,10 +15,10 @@ subjects:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}-leader-election
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
 roleRef:
   kind: ClusterRole
-  name: {{ default (include "kube-image-keeper.fullname" .) .Values.serviceAccount.name }}-leader-election
+  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/helm/kube-image-keeper/templates/controller-deployment.yaml
+++ b/helm/kube-image-keeper/templates/controller-deployment.yaml
@@ -39,6 +39,7 @@ spec:
             - -expiry-delay={{ .Values.cachedImagesExpiryDelay }}
             - -proxy-port={{ .Values.proxy.hostPort }}
             - -ignore-namespace={{ .Release.Namespace }}
+            - -registry-endpoint={{ include "kube-image-keeper.fullname" . }}-registry:5000
             - -zap-log-level={{ .Values.controllers.verbosity }}
           ports:
             - containerPort: 9443
@@ -68,4 +69,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: {{ include "kube-image-keeper.fullname" . }}-webhook-server-cert

--- a/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
@@ -6,7 +6,7 @@ apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:
-  name: registry-garbage-collection
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-garbage-collection
   labels:
     {{- include "kube-image-keeper.garbage-collection-labels" . | nindent 4 }}
 spec:
@@ -18,7 +18,7 @@ spec:
       activeDeadlineSeconds: 600
       template:
         spec:
-          serviceAccountName: registry-restart
+          serviceAccountName: {{ include "kube-image-keeper.fullname" . }}-registry-restart
           restartPolicy: Never
           containers:
             - name: kubectl
@@ -27,6 +27,6 @@ spec:
                 - bash
                 - -c
                 - >-
-                  kubectl rollout restart sts registry &&
-                  kubectl rollout status sts registry
+                  kubectl rollout restart sts {{ include "kube-image-keeper.fullname" . }}-registry &&
+                  kubectl rollout status sts {{ include "kube-image-keeper.fullname" . }}-registry
 {{- end }}

--- a/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
@@ -6,7 +6,7 @@ apiVersion: batch/v1beta1
 {{- end }}
 kind: CronJob
 metadata:
-  name: {{ include "kube-image-keeper.fullname" . }}-garbage-collection
+  name: registry-garbage-collection
   labels:
     {{- include "kube-image-keeper.garbage-collection-labels" . | nindent 4 }}
 spec:
@@ -27,6 +27,6 @@ spec:
                 - bash
                 - -c
                 - >-
-                  kubectl rollout restart sts {{ include "kube-image-keeper.fullname" . }} &&
-                  kubectl rollout status sts {{ include "kube-image-keeper.fullname" . }}
+                  kubectl rollout restart sts registry &&
+                  kubectl rollout status sts registry
 {{- end }}

--- a/helm/kube-image-keeper/templates/garbage-collection-role-binding.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-role-binding.yaml
@@ -2,14 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: registry-restart
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-restart
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: registry-restart
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-restart
 subjects:
   - kind: ServiceAccount
-    name: registry-restart
+    name: {{ include "kube-image-keeper.fullname" . }}-registry-restart
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/helm/kube-image-keeper/templates/garbage-collection-role.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-role.yaml
@@ -6,6 +6,6 @@ metadata:
 rules:
   - apiGroups: ["apps", "extensions"]
     resources: ["statefulsets"]
-    resourceNames: [{{ include "kube-image-keeper.fullname" . }}]
+    resourceNames: ["registry"]
     verbs: ["get", "patch", "list", "watch"]
 {{- end }}

--- a/helm/kube-image-keeper/templates/garbage-collection-role.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-role.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: registry-restart
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-restart
 rules:
   - apiGroups: ["apps", "extensions"]
     resources: ["statefulsets"]
-    resourceNames: ["registry"]
+    resourceNames: ["{{ include "kube-image-keeper.fullname" . }}-registry"]
     verbs: ["get", "patch", "list", "watch"]
 {{- end }}

--- a/helm/kube-image-keeper/templates/garbage-collection-service-account.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-service-account.yaml
@@ -2,5 +2,5 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: registry-restart
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-restart
 {{- end }}

--- a/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
@@ -3,7 +3,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kuik-serving-cert
-  name: kuik-mutating-webhook-configuration
+  name: kuik-mutating-webhook
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
@@ -2,15 +2,15 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kuik-serving-cert
-  name: kuik-mutating-webhook
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kube-image-keeper.fullname" . }}-serving-cert
+  name: {{ include "kube-image-keeper.fullname" . }}-mutating-webhook
 webhooks:
 - admissionReviewVersions:
   - v1
   - v1beta1
   clientConfig:
     service:
-      name: kuik-webhook
+      name: {{ include "kube-image-keeper.fullname" . }}-webhook
       namespace: {{ .Release.Namespace }}
       path: /mutate-core-v1-pod
   failurePolicy: Ignore

--- a/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
+++ b/helm/kube-image-keeper/templates/mutatingwebhookconfiguration.yaml
@@ -10,7 +10,7 @@ webhooks:
   - v1beta1
   clientConfig:
     service:
-      name: kuik-webhook-service
+      name: kuik-webhook
       namespace: {{ .Release.Namespace }}
       path: /mutate-core-v1-pod
   failurePolicy: Ignore

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: registry
+  name: {{ include "kube-image-keeper.fullname" . }}-registry
   labels:
     {{- include "kube-image-keeper.registry-labels" . | nindent 4 }}
 spec:
-  serviceName: registry
+  serviceName: {{ include "kube-image-keeper.fullname" . }}-registry
   selector:
     matchLabels:
       {{- include "kube-image-keeper.registry-selectorLabels" . | nindent 6 }}

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "kube-image-keeper.fullname" . }}
+  name: registry
   labels:
     {{- include "kube-image-keeper.registry-labels" . | nindent 4 }}
 spec:
-  serviceName: {{ .Release.Name }}
+  serviceName: registry
   selector:
     matchLabels:
       {{- include "kube-image-keeper.registry-selectorLabels" . | nindent 6 }}
@@ -39,7 +39,7 @@ spec:
           {{- if .Values.registry.persistence.enabled }}
           volumeMounts:
             - mountPath: /var/lib/registry
-              name: {{ include "kube-image-keeper.fullname" . }}-data
+              name: data
           {{- end }}
         - name: garbage-collector
           image: "{{ .Values.registry.image.repository }}:{{ .Values.registry.image.tag }}"
@@ -54,7 +54,7 @@ spec:
           {{- if .Values.registry.persistence.enabled }}
           volumeMounts:
             - mountPath: /var/lib/registry
-              name: {{ include "kube-image-keeper.fullname" . }}-data
+              name: data
           {{- end }}
       {{- end }}
       containers:
@@ -78,7 +78,7 @@ spec:
           {{- if .Values.registry.persistence.enabled }}
           volumeMounts:
             - mountPath: /var/lib/registry
-              name: {{ include "kube-image-keeper.fullname" . }}-data
+              name: data
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -95,7 +95,7 @@ spec:
 {{- if .Values.registry.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ include "kube-image-keeper.fullname" . }}-data
+      name: data
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .Values.registry.persistence.storageClass }}

--- a/helm/kube-image-keeper/templates/registry-ui-deployment.yaml
+++ b/helm/kube-image-keeper/templates/registry-ui-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.registryUI.resources | nindent 12 }}
           env:
             - name: REGISTRY_HOST
-              value: kube-image-keeper-service
+              value: registry
             - name: REGISTRY_PORT
               value: "5000"
             - name: REGISTRY_PROTOCOL

--- a/helm/kube-image-keeper/templates/registry-ui-deployment.yaml
+++ b/helm/kube-image-keeper/templates/registry-ui-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.registryUI.resources | nindent 12 }}
           env:
             - name: REGISTRY_HOST
-              value: registry
+              value: {{ include "kube-image-keeper.fullname" . }}-registry
             - name: REGISTRY_PORT
               value: "5000"
             - name: REGISTRY_PROTOCOL

--- a/helm/kube-image-keeper/templates/service.yaml
+++ b/helm/kube-image-keeper/templates/service.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  # name: {{ include "kube-image-keeper.fullname" . }}
-  name: kube-image-keeper-service
+  name: registry
   labels:
     {{- include "kube-image-keeper.registry-labels" . | nindent 4 }}
 spec:

--- a/helm/kube-image-keeper/templates/service.yaml
+++ b/helm/kube-image-keeper/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: registry
+  name: {{ include "kube-image-keeper.fullname" . }}-registry
   labels:
     {{- include "kube-image-keeper.registry-labels" . | nindent 4 }}
 spec:

--- a/helm/kube-image-keeper/templates/webhook-certificate.yaml
+++ b/helm/kube-image-keeper/templates/webhook-certificate.yaml
@@ -4,8 +4,8 @@ metadata:
   name: kuik-serving-cert
 spec:
   dnsNames:
-  - kuik-webhook-service.{{ .Release.Namespace }}.svc
-  - kuik-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  - kuik-webhook.{{ .Release.Namespace }}.svc
+  - kuik-webhook.{{ .Release.Namespace }}.svc.cluster.local
   secretName: webhook-server-cert
   issuerRef:
     {{- toYaml .Values.controllers.webhook.certificateIssuerRef | nindent 4 }}

--- a/helm/kube-image-keeper/templates/webhook-certificate.yaml
+++ b/helm/kube-image-keeper/templates/webhook-certificate.yaml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: kuik-serving-cert
+  name: {{ include "kube-image-keeper.fullname" . }}-serving-cert
 spec:
   dnsNames:
-  - kuik-webhook.{{ .Release.Namespace }}.svc
-  - kuik-webhook.{{ .Release.Namespace }}.svc.cluster.local
-  secretName: webhook-server-cert
+  - {{ include "kube-image-keeper.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
+  - {{ include "kube-image-keeper.fullname" . }}-webhook.{{ .Release.Namespace }}.svc.cluster.local
+  secretName: {{ include "kube-image-keeper.fullname" . }}-webhook-server-cert
   issuerRef:
     {{- toYaml .Values.controllers.webhook.certificateIssuerRef | nindent 4 }}
 ---
@@ -14,7 +14,7 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: kuik-selfsigned-issuer
+  name: {{ include "kube-image-keeper.fullname" . }}-selfsigned-issuer
 spec:
   selfSigned: {}
 {{- end -}}

--- a/helm/kube-image-keeper/templates/webhook-service.yaml
+++ b/helm/kube-image-keeper/templates/webhook-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuik-webhook
+  name: {{ include "kube-image-keeper.fullname" . }}-webhook
 spec:
   ports:
   - port: 443

--- a/helm/kube-image-keeper/templates/webhook-service.yaml
+++ b/helm/kube-image-keeper/templates/webhook-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kuik-webhook-service
+  name: kuik-webhook
 spec:
   ports:
   - port: 443

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-var Endpoint = "registry:5000"
+var Endpoint = "kuik-registry:5000"
 var Protocol = "http://"
 
 // See https://github.com/kubernetes/apimachinery/blob/v0.20.6/pkg/util/validation/validation.go#L198

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
-var Endpoint = "kube-image-keeper-service:5000"
+var Endpoint = "registry:5000"
 var Protocol = "http://"
 
 // See https://github.com/kubernetes/apimachinery/blob/v0.20.6/pkg/util/validation/validation.go#L198

--- a/test-helm-fullname-helper.sh
+++ b/test-helm-fullname-helper.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+function test() {
+    local expected="$2"
+    local expected2='fullnameOverride'
+    output=$(helm template helm/kube-image-keeper/ -s templates/test-templating.yaml $1 | egrep '^kind:' | cut -c 7-)
+    output2=$(helm template helm/kube-image-keeper/ -s templates/test-templating.yaml $1 --set fullnameOverride=fullnameOverride | egrep '^kind:'| cut -c 7-)
+
+    echo "args: $1"
+    if [[ $expected == $output ]]; then
+        echo OK
+    else
+        echo -e "\033[0;31mKO: '$output' != '$expected'\033[0m"
+    fi
+
+    if [[ $expected2 == $output2 ]]; then
+        echo OK2
+    else
+        echo -e "\033[0;31mKO2: '$output2' != '$expected2'\033[0m"
+    fi
+    echo "----------"
+}
+
+# has to be compatible with https://pkg.go.dev/helm.sh/helm/v3/pkg/releaseutil#SimpleHead
+echo """
+kind: {{ include \"kube-image-keeper.fullname\" . }}
+""" > helm/kube-image-keeper/templates/test-templating.yaml
+
+# basic
+test ''                                             'release-name-kuik'
+test '--name-template foo'                          'foo-kuik'
+test '--set nameOverride=bar'                       'release-name-bar'
+test '--name-template foo --set nameOverride=bar'   'foo-bar'
+test '--name-template foo --set nameOverride=foo'   'foo'
+
+# replace kube-image-keeper by kuik
+test '--name-template kube-image-keeper'            'kuik'
+test '--name-template kuik'                         'kuik'
+## with -release postfix
+test '--name-template kuik-release'                 'kuik-release'
+test '--name-template kube-image-keeper-release'    'kuik-release'
+## with one missing letter
+test '--name-template kui'                          'kui-kuik'
+test '--name-template kube-image-keepe'             'kube-image-keepe-kuik'
+
+# merge duplicate names
+test '--name-template kuik              --set nameOverride=kuik'                'kuik'
+test '--name-template kube-image-keeper --set nameOverride=kuik'                'kuik'
+## nameOverride should be taken in account as is and not be replaced
+test '--name-template kuik              --set nameOverride=kube-image-keeper'   'kuik-kube-image-keeper'
+test '--name-template kube-image-keeper --set nameOverride=kube-image-keeper'   'kuik-kube-image-keeper'
+
+rm -f helm/kube-image-keeper/templates/test-templating.yaml


### PR DESCRIPTION
This PR tries to harmonize naming between helm resources and fix some naming issues as well.

1. Registry statefulset was originally named "cache-registry" at the time the project was also called "cache-registry". Thus, when reworking the chart, its name was replaced by a template to name it by the name of the project. Then, when the project was renamed kube-image-keeper, the registry name was templated as kube-image-keeper instead of cache-registry. This commit intend to fix this mistake and set a proper name for the registry.
2. All resources are now prefixed with the `kube-image-keeper.fullname` helper, which by default when following the installation steps in the readme is `kuik`. It still can be customized using values `nameOverride` and `fullnameOverride` or by giving another name than the standard one (`kube-image-keeper`) to the helm release. It follows those rules (see `test-helm-fullname-helper.sh` file for examples) :
   - Fullname = `releaseName-name`
   - By default, `name` = "kuik" but it can be overridden by specifying `nameOverride` value
   - If the release is named "kube-image-keeper", then it is shortened as "kuik" in the fullname
   - If `releaseName` contains `name` it will be used as a full name to avoid repetition.
   - The fullname can be completely overridden by specifying `fullnameOverride` value

⚠️ The renaming create a new PVC for the registry, thus invalidate the cache.