### PR TITLE
helm chart: make the proxy hostIp parameter configurable

### DIFF
--- a/helm/kube-image-keeper/templates/proxy-daemonset.yaml
+++ b/helm/kube-image-keeper/templates/proxy-daemonset.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           ports:
             - containerPort: 8082
-              hostIP: 127.0.0.1
+              hostIP: {{ .Values.proxy.hostIp }}
               hostPort: {{ .Values.proxy.hostPort }}
               protocol: TCP
           command:

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -69,6 +69,8 @@ proxy:
     tag: ""
   # -- hostPort used for the proxy pod
   hostPort: 7439
+  # -- hostIp used for the proxy pod
+  hostIp: "127.0.0.1"
   # -- Verbosity level for the proxy pod
   verbosity: 1
   # -- Specify secrets to be used when pulling proxy image


### PR DESCRIPTION
When using cilium, removing hostIp from the daemonset helps to make it work, so we make this parameter configurable (while keeping the default of 127.0.0.1).