### PR TITLE
allow the proxy to be a deployment (instead of a daemonset)

### DIFF
--- a/api/v1/pod_webhook_test.go
+++ b/api/v1/pod_webhook_test.go
@@ -33,7 +33,8 @@ func TestRewriteImages(t *testing.T) {
 	g := NewWithT(t)
 	t.Run("rewrite image", func(t *testing.T) {
 		ir := ImageRewriter{
-			ProxyPort: 4242,
+			ProxyAddress: "localhost",
+			ProxyPort:    4242,
 		}
 		ir.RewriteImages(&podStub)
 

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -32,6 +32,7 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var expiryDelay uint
+	var proxyAddress string
 	var proxyPort int
 	var ignoreNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -40,7 +41,8 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.UintVar(&expiryDelay, "expiry-delay", 30, "The delay in days before deleting an unused CachedImage.")
-	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port where the proxy is listening on this machine.")
+	flag.StringVar(&proxyAddress, "proxy-address", "localhost", "The address of the proxy.")
+	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port of the proxy.")
 	flag.StringVar(&ignoreNamespace, "ignore-namespace", "kuik-system", "The address the probe endpoint binds to.")
 	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kube-image-keeper-registry:5000", "The address of the registry where cached images are stored.")
 	opts := zap.Options{
@@ -84,6 +86,7 @@ func main() {
 	imageRewriter := kuikenixiov1.ImageRewriter{
 		Client:          mgr.GetClient(),
 		IgnoreNamespace: ignoreNamespace,
+		ProxyAddress:    proxyAddress,
 		ProxyPort:       proxyPort,
 	}
 	mgr.GetWebhookServer().Register("/mutate-core-v1-pod", &webhook.Admission{Handler: &imageRewriter})

--- a/helm/kube-image-keeper/templates/controller-deployment.yaml
+++ b/helm/kube-image-keeper/templates/controller-deployment.yaml
@@ -37,7 +37,8 @@ spec:
             - manager
             - -leader-elect
             - -expiry-delay={{ .Values.cachedImagesExpiryDelay }}
-            - -proxy-port={{ .Values.proxy.hostPort }}
+            - -proxy-address={{ .Values.controllers.proxyAddress }}
+            - -proxy-port={{ or .Values.controllers.proxyPort .Values.proxy.hostPort }}
             - -ignore-namespace={{ .Release.Namespace }}
             - -registry-endpoint={{ include "kube-image-keeper.fullname" . }}-registry:5000
             - -zap-log-level={{ .Values.controllers.verbosity }}

--- a/helm/kube-image-keeper/templates/proxy-daemonset.yaml
+++ b/helm/kube-image-keeper/templates/proxy-daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: {{ .Values.proxy.kind }}
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-proxy
   labels:

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -58,8 +58,14 @@ controllers:
     objectSelector:
       # -- Run the webhook if the object has matching labels. (See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#labelselectorrequirement-v1-meta)
       matchExpressions: []
+  # -- proxyAddress default to localhost, change it when using a clusterip
+  proxyAddress: localhost
+  # -- proxyPort defaults to proxy.hostPort
+  #proxyPort: ""
 
 proxy:
+  # -- kind of resource, could be DaemonSet (default), Deployment or StatefulSet
+  kind: DaemonSet
   image:
     # -- Proxy image repository. Also available: `quay.io/enix/kube-image-keeper`
     repository: enix/kube-image-keeper


### PR DESCRIPTION
added parameters :
- controllers.proxyAddress
- controllers.proxyPort
- proxy.kind 

Combined with a hostIp service, this allows to have only one (or a few) instance(s) of the proxy, accessible through that IP, instead of one instance per node. For this to work, you need to use the hostIp directly (containerd cannot query the DNS for the service IP, because the DNS lives inside the cluster). 

Example of service definition : 
```yaml
apiVersion: v1
kind: Service
metadata:
  name: kuik-proxy
  namespace: kuik-system
spec:
  ports:
  - name: registry
    port: 7439
    protocol: TCP
    targetPort: 8082
  selector:
    app.kubernetes.io/component: proxy
  type: ClusterIP
  clusterIP: "100.64.64.64"
```

Example of values : 
```yaml
controllers:
  proxyAddress: "100.64.64.64"
  proxyPort: 7439
proxy:
  kind: Deployment
  hostPort: ""
  hostIp: ""
```

Finally, containerd will try to access the registry as https instead of http, to convince it to use http, configure a mirror like so : 

```toml
version = 2

[plugins]
    ...
    [plugins."io.containerd.grpc.v1.cri".registry]

      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]

        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."100.64.64.64:7439"]
          endpoint = ["http://100.64.64.64:7439"]
```