### PR TITLE
tests: fix Test_CacheImage fails randomly

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -300,14 +300,16 @@ func Test_CacheImage(t *testing.T) {
 
 			cacheRegistry := ghttp.NewServer()
 			defer cacheRegistry.Close()
+			// those paths can be called in any order
+			pathMatcher := Or(Equal("/v2/"+originRegistryName+"/"+tt.image+"/blobs/"+layerSha), Equal("/v2/"+originRegistryName+"/"+tt.image+"/blobs/"+digestSha))
 			cacheRegistry.AppendHandlers(
 				mockV2Endpoint(gh),
 				ghttp.CombineHandlers(
-					gh.VerifyRequest(http.MethodHead, "/v2/"+originRegistryName+"/"+tt.image+"/blobs/"+layerSha),
+					gh.VerifyRequest(http.MethodHead, pathMatcher),
 					gh.RespondWith(http.StatusOK, "...", mockedHeadImageHeader),
 				),
 				ghttp.CombineHandlers(
-					gh.VerifyRequest(http.MethodHead, "/v2/"+originRegistryName+"/"+tt.image+"/blobs/"+digestSha),
+					gh.VerifyRequest(http.MethodHead, pathMatcher),
 					gh.RespondWith(http.StatusOK, "...", mockedHeadImageHeader),
 				),
 				ghttp.CombineHandlers(


### PR DESCRIPTION
The layer and digests paths can be called randomly in any order, it then cause the test to fail when the order is not the one expected.