### PR TITLE
Allow to set the maximum concurrency in CachedImages operations

### DIFF
--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -34,6 +34,7 @@ func main() {
 	var expiryDelay uint
 	var proxyPort int
 	var ignoreNamespace string
+	var maxConcurrentCachedImageReconciles int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -43,6 +44,8 @@ func main() {
 	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port where the proxy is listening on this machine.")
 	flag.StringVar(&ignoreNamespace, "ignore-namespace", "kuik-system", "The address the probe endpoint binds to.")
 	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kube-image-keeper-registry:5000", "The address of the registry where cached images are stored.")
+	flag.IntVar(&maxConcurrentCachedImageReconciles, "max-concurrent-cached-image-reconciles", 3, "Maximum number of CachedImages that can be handled and reconciled at the same time (put or removed from cache).")
+
 	opts := zap.Options{
 		Development:     true,
 		TimeEncoder:     zapcore.ISO8601TimeEncoder,
@@ -70,7 +73,7 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("cachedimage-controller"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, maxConcurrentCachedImageReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CachedImage")
 		os.Exit(1)
 	}

--- a/controllers/cachedimage_controller.go
+++ b/controllers/cachedimage_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -148,7 +149,7 @@ func (r *CachedImageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *CachedImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *CachedImageReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	// Create an index to list Pods by CachedImage
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, cachedImageOwnerKey, func(rawObj client.Object) []string {
 		pod := rawObj.(*corev1.Pod)
@@ -175,6 +176,9 @@ func (r *CachedImageReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuikenixiov1alpha1.CachedImage{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
 		Complete(r)
 }
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Recorder: k8sManager.GetEventRecorderFor("cachedimage-controller"),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, 3)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PodReconciler{

--- a/helm/kube-image-keeper/templates/controller-deployment.yaml
+++ b/helm/kube-image-keeper/templates/controller-deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - -proxy-port={{ .Values.proxy.hostPort }}
             - -ignore-namespace={{ .Release.Namespace }}
             - -registry-endpoint={{ include "kube-image-keeper.fullname" . }}-registry:5000
+            - -max-concurrent-cached-image-reconciles={{ .Values.controllers.maxConcurrentCachedImageReconciles }}
             - -zap-log-level={{ .Values.controllers.verbosity }}
           ports:
             - containerPort: 9443

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -9,6 +9,8 @@ cachedImagesExpiryDelay: 30
 installCRD: true
 
 controllers:
+  # Maximum number of CachedImages that can be handled and reconciled at the same time (put or remove from cache)
+  maxConcurrentCachedImageReconciles: 3
   # -- Number of controllers
   replicas: 2
   image:


### PR DESCRIPTION
It allows to put in cache or remove from the cache multiple images at the same time in order to speed up the process.