### PR TITLE
Fix/pod count

### DIFF
--- a/controllers/cachedimage_controller.go
+++ b/controllers/cachedimage_controller.go
@@ -46,15 +46,13 @@ func (r *CachedImageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	log := log.
 		FromContext(ctx)
 
-	log.Info("reconciling cachedimage")
-
 	var cachedImage kuikenixiov1alpha1.CachedImage
 	if err := r.Get(ctx, req.NamespacedName, &cachedImage); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// https://book.kubebuilder.io/reference/using-finalizers.html
-	finalizerName := "cachedimage.kuik.enix.io/finalizer"
+	log.Info("reconciling cachedimage")
+
 	// Remove image from registry when CachedImage is being deleted, finalizer is removed after it
 	if !cachedImage.ObjectMeta.DeletionTimestamp.IsZero() {
 		if containsString(cachedImage.GetFinalizers(), finalizerName) {

--- a/controllers/pod_controller.go
+++ b/controllers/pod_controller.go
@@ -58,11 +58,12 @@ type PodReconciler struct {
 func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
 
-	log.Info("reconciling pod")
 	var pod corev1.Pod
 	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	log.Info("reconciling pod")
 
 	cachedImages := desiredCachedImages(ctx, &pod)
 


### PR DESCRIPTION
When deleting CachedImage in use, at the time it was recreated, its usedBy status wasn't updated. Updating the status from the CachedImage controller instead of the Pod controller fixed it as the status is now updated each time a CachedImage is updated.

The PR fixes also minors issues like the reconciliation of related Pods being triggered more than once when a CachedImage was deleted and messages about reconciliation being logged even when the related object didn't exists anymore and the reconciliation process was aborted.