### PR TITLE
feat(proxy): make Kube client throttling rates configurable

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -59,14 +59,15 @@ func main() {
 		panic(err)
 	}
 
+	restMapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
+	if err != nil {
+		panic(err)
+	}
+
 	// Set rate limiter only if both QPS and burst are set
 	if rateLimitQPS > 0 && rateLimitBurst > 0 {
 		klog.Infof("setting Kubernetes API rate limiter to %d QPS and %d burst", rateLimitQPS, rateLimitBurst)
 		config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(float32(rateLimitQPS), rateLimitBurst)
-	}
-	restMapper, err := apiutil.NewDynamicRESTMapper(config, apiutil.WithLazyDiscovery)
-	if err != nil {
-		panic(err)
 	}
 
 	k8sClient, err := client.New(config, client.Options{

--- a/helm/kube-image-keeper/templates/proxy-daemonset.yaml
+++ b/helm/kube-image-keeper/templates/proxy-daemonset.yaml
@@ -45,6 +45,10 @@ spec:
             - registry-proxy
             - -v={{ .Values.proxy.verbosity }}
             - -registry-endpoint={{ include "kube-image-keeper.fullname" . }}-registry:5000
+            {{- with .Values.proxy.kubeApiRateLimits }}
+            - -kube-api-rate-limit-qps={{ .qps }}
+            - -kube-api-rate-limit-burst={{ .burst }}
+            {{- end }}
           {{- with .Values.proxy.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -161,6 +161,10 @@ proxy:
     extraLabels: {}
     # -- Relabel config for the ServiceMonitor, see: https://coreos.com/operators/prometheus/docs/latest/api.html#relabelconfig
     relabelings: []
+  kubeApiRateLimits: {}
+    # -- Try higher values if there's a lot of CRDs installed in the cluster and proxy start takes a long time because of throttling
+    # qps: 5
+    # burst: 10
 
 registry:
   image:


### PR DESCRIPTION
Currently we have more than 1k of CRDs installed in the cluster (because of Crossplane) so proxy start takes ~34 seconds.
Nodes are dynamically created and destroyed hundreds times per day as they are used as build nodes for CI/CD. So build pods often land on fresh nodes with images pointing to Kuik proxy that has not fully booted yet and get "dial tcp [::1]:7439: connect: connection refused" error and fail (see https://github.com/enix/kube-image-keeper/issues/102 for more details).

Increasing Kube API rate limits to 100 qps and 500 burst makes proxy start almost instantly and solves this problem. This PR makes these settings configurable from helm chart.

Tested on EKS cluster.