### PR TITLE
Setting registry.persistence.s3ExistingSecret makes helm install fail

### DIFF
--- a/helm/kube-image-keeper/templates/s3-registry-keys.yaml
+++ b/helm/kube-image-keeper/templates/s3-registry-keys.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.minio.enabled (not (empty .Values.registry.persistence.s3)) }}
+{{- if or .Values.minio.enabled (and (not (empty .Values.registry.persistence.s3)) (empty .Values.registry.persistence.s3ExistingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
We don't need to create a secret when setting `registry.persistence.s3ExistingSecret`. Creating it makes helm install fail.