### PR TITLE
feat(controller): multi-platform images support

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
 var Endpoint = ""
@@ -105,7 +106,7 @@ func CacheImage(imageName string, keychain authn.Keychain) error {
 	}
 
 	auth := remote.WithAuthFromKeychain(keychain)
-	image, err := remote.Image(sourceRef, auth)
+	desc, err := remote.Get(sourceRef, auth)
 	if err != nil {
 		if errIsImageNotFound(err) {
 
@@ -114,8 +115,23 @@ func CacheImage(imageName string, keychain authn.Keychain) error {
 		return err
 	}
 
-	if err := remote.Write(destRef, image); err != nil {
-		return err
+	switch desc.MediaType {
+	case types.OCIImageIndex, types.DockerManifestList:
+		index, err := desc.ImageIndex()
+		if err != nil {
+			return err
+		}
+		if err := remote.WriteIndex(destRef, index); err != nil {
+			return err
+		}
+	default:
+		image, err := desc.Image()
+		if err != nil {
+			return err
+		}
+		if err := remote.Write(destRef, image); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
By default remote.Image/remote.Write will copy only one platform of the multi-platform image. If such image is used and cached by Kuik, aarch64/linux fails to start immediately with error 1. Presumably this happens because go-containerimage library is using amd64/linux as [default platform](https://github.com/google/go-containerregistry/blob/v0.12.1/pkg/v1/remote/options.go#L51) and only one image gets cached in internal registry instead of full set of platforms.

It's possible to workaround this by finding image alternatives which contain architecture in their name or tag (e.g. use `arm64v8/docker:20-dind` instead of `library/docker:20-dind`, but it would be more convenient if Kuik could support such images out of the box.

Fixes https://github.com/enix/kube-image-keeper/issues/104.