### PR TITLE
feat(helm): make delete-untagged registry flag configurable from helm

### DIFF
--- a/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.registry.garbageCollectionSchedule (or .Values.registry.persistence.enabled (eq (include "kube-image-keeper.registry-stateless-mode" .) "true")) }}
+{{- if and .Values.registry.garbageCollection.schedule (or .Values.registry.persistence.enabled (eq (include "kube-image-keeper.registry-stateless-mode" .) "true")) }}
 {{- if semverCompare ">=1.21-0" (default .Capabilities.KubeVersion.Version .Values.kubeVersion) -}}
 apiVersion: batch/v1
 {{- else -}}
@@ -11,7 +11,7 @@ metadata:
     {{- include "kube-image-keeper.garbage-collection-labels" . | nindent 4 }}
 spec:
   concurrencyPolicy: Forbid
-  schedule: "{{ .Values.registry.garbageCollectionSchedule }}"
+  schedule: "{{ .Values.registry.garbageCollection.schedule }}"
   jobTemplate:
     spec:
       backoffLimit: 3

--- a/helm/kube-image-keeper/templates/garbage-collection-role-binding.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.registry.garbageCollectionSchedule }}
+{{- if .Values.registry.garbageCollection.schedule }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/kube-image-keeper/templates/garbage-collection-role.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.registry.garbageCollectionSchedule }}
+{{- if .Values.registry.garbageCollection.schedule }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/kube-image-keeper/templates/garbage-collection-service-account.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-service-account.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.registry.garbageCollectionSchedule }}
+{{- if .Values.registry.garbageCollection.schedule }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
             - bin/registry
             - garbage-collect
             - /etc/docker/registry/config.yml
-            - --delete-untagged=true
+            - --delete-untagged={{ .Values.registry.garbageCollection.deleteUntagged }}
           resources:
             {{- toYaml .Values.registry.resources | nindent 12 }}
           {{- if .Values.registry.persistence.enabled }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -167,8 +167,11 @@ registry:
     # -- External S3 configuration (needed only if you don't enable minio) (see https://github.com/docker/docs/blob/main/registry/storage-drivers/s3.md)
     s3: {}
     s3ExistingSecret: ""
-  # -- Garbage collector cron schedule. Use standard crontab format.
-  garbageCollectionSchedule: "0 0 * * 0"
+  garbageCollection:
+    # -- Garbage collector cron schedule. Use standard crontab format.
+    schedule: "0 0 * * 0"
+    # -- If true, delete untagged manifests
+    deleteUntagged: true
   service:
     # -- Registry service type
     type: ClusterIP


### PR DESCRIPTION
Make `--delete-untagged` flag used with `registry garbage-collect` command configurable from helm chart.

**Rationale**:
Faced the bug in `registry` which makes it crash during garbage collection:
```
public.ecr.aws/docker/library/python
public.ecr.aws/docker/library/python: marking manifest sha256:281811c93dbf7b29719709c129230edfa1b10585d720f95c60363a358e49b62c 
public.ecr.aws/docker/library/python: marking blob sha256:d56c84cce2aab1191d519b6881efe21d463c69fdc5ec0c349dce4e5fde19d712
public.ecr.aws/docker/library/python: marking blob sha256:31e352740f534f9ad170f75378a84fe453d6156e40700b882d737a8f4a6988a3
public.ecr.aws/docker/library/python: marking blob sha256:cfcc276e4459ecb909a4257fdf7647034eb3b2ab1f0d0c0bba54856c39079c50
public.ecr.aws/docker/library/python: marking blob sha256:baaf570859b366295c3a4cdfa37f657584edc590ca2e0a210c29fce663e5135a
public.ecr.aws/docker/library/python: marking blob sha256:7523d885c165069449030cb9f473ed4e33cfb7fbb7aff2dc3d7e70bdbde6fa78
public.ecr.aws/docker/library/python: marking blob sha256:7d3b4e99205641d0ec41cb1f31c65ad0f889903b35c395a8c92de7439adfa226
public.ecr.aws/karpenter/controller
manifest eligible for deletion: sha256:4194fc219d5a1019cd8d7d69f518b903e972966cad2e9420ccbe9dca149f179d
failed to garbage collect: failed to mark: filesystem: filesystem: failed to retrieve tags unknown repository name=public.ecr.aws/karpenter/controller
```
Since garbage collection runs as initContainer, it blocks registry itself as well.