### PR TITLE
fix(helm): avoid deadloop by skipping own images from being cached

### DIFF
--- a/helm/kube-image-keeper/templates/_helpers.tpl
+++ b/helm/kube-image-keeper/templates/_helpers.tpl
@@ -74,6 +74,7 @@ Selector labels
 {{- define "kube-image-keeper.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kube-image-keeper.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+kube-image-keeper.enix.io/image-caching-policy: ignore
 {{- end }}
 
 {{- define "kube-image-keeper.controllers-selectorLabels" -}}


### PR DESCRIPTION
Make sure that Kuik does not depend on itself. So if it fails, it doesn't block itself from fetching the images and starting.