### PR TITLE
fix(controllers): remove pods finalizer

### DIFF
--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -70,17 +70,17 @@ func main() {
 	}
 
 	if err = (&controllers.CachedImageReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("cachedimage-controller"),
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		Recorder:    mgr.GetEventRecorderFor("cachedimage-controller"),
+		ExpiryDelay: time.Duration(expiryDelay*24) * time.Hour,
 	}).SetupWithManager(mgr, maxConcurrentCachedImageReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "CachedImage")
 		os.Exit(1)
 	}
 	if err = (&controllers.PodReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		ExpiryDelay: time.Duration(expiryDelay*24) * time.Hour,
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pod")
 		os.Exit(1)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -138,16 +138,16 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&CachedImageReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: k8sManager.GetEventRecorderFor("cachedimage-controller"),
+		Client:      k8sManager.GetClient(),
+		Scheme:      k8sManager.GetScheme(),
+		Recorder:    k8sManager.GetEventRecorderFor("cachedimage-controller"),
+		ExpiryDelay: 1 * time.Hour,
 	}).SetupWithManager(k8sManager, 3)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&PodReconciler{
-		Client:      k8sManager.GetClient(),
-		Scheme:      k8sManager.GetScheme(),
-		ExpiryDelay: 1 * time.Hour,
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Finalizer on Pods were used to handle the expiry of CachedImages before deleting Pods because the logic of setting the `expiresAt` field was handled by the PodController. The goal of this PR is to compute all CachedImages' related information on the CachedImagesController side. The finalizer on Pods is thus no longer needed.

This PR also includes a fix: when an image get used by more pods (eg. scaling of a deployment), the pod count status was not updated.

⚠️ Pods from previous deployments will still have the kuik finalizer on Pods. Since after this change the controller does not remove finalizers, we should find a way to remove all kuik finalizers on pods when upgrading.

Closes #135