### PR TITLE
refactor: remove ignore-namespace flag

### DIFF
--- a/api/v1/pod_webhook.go
+++ b/api/v1/pod_webhook.go
@@ -14,35 +14,25 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 //+kubebuilder:webhook:path=/mutate-core-v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups=core,resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io,admissionReviewVersions=v1
 
 type ImageRewriter struct {
-	Client          client.Client
-	IgnoreNamespace string
-	ProxyPort       int
-	decoder         *admission.Decoder
+	Client    client.Client
+	ProxyPort int
+	decoder   *admission.Decoder
 }
 
 func (a *ImageRewriter) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := log.
-		FromContext(ctx).
-		WithName("controller-runtime.webhook.pod")
-
 	pod := &corev1.Pod{}
 	err := a.decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if req.Namespace != a.IgnoreNamespace {
-		a.RewriteImages(pod)
-	} else {
-		log.Info("Ignoring pod from ignored namespace", "namespace", req.Namespace)
-	}
+	a.RewriteImages(pod)
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -33,7 +33,6 @@ func main() {
 	var probeAddr string
 	var expiryDelay uint
 	var proxyPort int
-	var ignoreNamespace string
 	var maxConcurrentCachedImageReconciles int
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -42,7 +41,6 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.UintVar(&expiryDelay, "expiry-delay", 30, "The delay in days before deleting an unused CachedImage.")
 	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port where the proxy is listening on this machine.")
-	flag.StringVar(&ignoreNamespace, "ignore-namespace", "kuik-system", "The address the probe endpoint binds to.")
 	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kube-image-keeper-registry:5000", "The address of the registry where cached images are stored.")
 	flag.IntVar(&maxConcurrentCachedImageReconciles, "max-concurrent-cached-image-reconciles", 3, "Maximum number of CachedImages that can be handled and reconciled at the same time (put or removed from cache).")
 
@@ -86,9 +84,8 @@ func main() {
 		os.Exit(1)
 	}
 	imageRewriter := kuikenixiov1.ImageRewriter{
-		Client:          mgr.GetClient(),
-		IgnoreNamespace: ignoreNamespace,
-		ProxyPort:       proxyPort,
+		Client:    mgr.GetClient(),
+		ProxyPort: proxyPort,
 	}
 	mgr.GetWebhookServer().Register("/mutate-core-v1-pod", &webhook.Admission{Handler: &imageRewriter})
 	//+kubebuilder:scaffold:builder

--- a/helm/kube-image-keeper/templates/_helpers.tpl
+++ b/helm/kube-image-keeper/templates/_helpers.tpl
@@ -35,7 +35,6 @@ Common labels
 */}}
 {{- define "kube-image-keeper.labels" -}}
 helm.sh/chart: {{ include "kube-image-keeper.chart" . }}
-kube-image-keeper.enix.io/image-caching-policy: ignore
 {{ include "kube-image-keeper.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/kube-image-keeper/templates/controller-deployment.yaml
+++ b/helm/kube-image-keeper/templates/controller-deployment.yaml
@@ -41,7 +41,6 @@ spec:
             - -leader-elect
             - -expiry-delay={{ .Values.cachedImagesExpiryDelay }}
             - -proxy-port={{ .Values.proxy.hostPort }}
-            - -ignore-namespace={{ .Release.Namespace }}
             - -registry-endpoint={{ include "kube-image-keeper.fullname" . }}-registry:5000
             - -max-concurrent-cached-image-reconciles={{ .Values.controllers.maxConcurrentCachedImageReconciles }}
             - -zap-log-level={{ .Values.controllers.verbosity }}


### PR DESCRIPTION
The release namespace is already ignored by MutatingWebhookConfiguration.