### PR TITLE
fix: hash container names that are too long to be used as annotation key

### DIFF
--- a/api/v1/pod_webhook.go
+++ b/api/v1/pod_webhook.go
@@ -11,6 +11,7 @@ import (
 	_ "crypto/sha256"
 
 	"github.com/enix/kube-image-keeper/controllers"
+	"github.com/enix/kube-image-keeper/internal/registry"
 	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,13 +58,13 @@ func (a *ImageRewriter) RewriteImages(pod *corev1.Pod) {
 	// Handle Containers
 	for i := range pod.Spec.Containers {
 		container := &pod.Spec.Containers[i]
-		a.handleContainer(pod, container, fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, container.Name))
+		a.handleContainer(pod, container, registry.ContainerAnnotationKey(container.Name, false))
 	}
 
 	// Handle init containers
 	for i := range pod.Spec.InitContainers {
 		container := &pod.Spec.InitContainers[i]
-		a.handleContainer(pod, container, fmt.Sprintf(controllers.AnnotationOriginalInitImageTemplate, container.Name))
+		a.handleContainer(pod, container, registry.ContainerAnnotationKey(container.Name, true))
 	}
 }
 

--- a/api/v1/pod_webhook_test.go
+++ b/api/v1/pod_webhook_test.go
@@ -2,11 +2,11 @@ package v1
 
 import (
 	_ "crypto/sha256"
-	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/enix/kube-image-keeper/controllers"
+	"github.com/enix/kube-image-keeper/internal/registry"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,12 +59,12 @@ func TestRewriteImages(t *testing.T) {
 
 		g.Expect(podStub.Labels[controllers.LabelImageRewrittenName]).To(Equal("true"))
 
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalInitImageTemplate, "a")]).To(Equal("original-init"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "b")]).To(Equal("original"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "c")]).To(Equal("original-2"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "d")]).To(Equal("185.145.250.247:30042/alpine"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "e")]).To(Equal("185.145.250.247:30042/alpine:latest"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "f")]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("a", true)]).To(Equal("original-init"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("b", false)]).To(Equal("original"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("c", false)]).To(Equal("original-2"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("d", false)]).To(Equal("185.145.250.247:30042/alpine"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("e", false)]).To(Equal("185.145.250.247:30042/alpine:latest"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("f", false)]).To(Equal(""))
 	})
 }
 
@@ -99,12 +99,12 @@ func TestRewriteImagesWithIgnore(t *testing.T) {
 
 		g.Expect(podStub.Labels[controllers.LabelImageRewrittenName]).To(Equal("true"))
 
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalInitImageTemplate, "a")]).To(Equal(""))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "b")]).To(Equal(""))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "c")]).To(Equal(""))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "d")]).To(Equal("185.145.250.247:30042/alpine"))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "e")]).To(Equal(""))
-		g.Expect(podStub.Annotations[fmt.Sprintf(controllers.AnnotationOriginalImageTemplate, "f")]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("a", true)]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("b", false)]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("c", false)]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("d", false)]).To(Equal("185.145.250.247:30042/alpine"))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("e", false)]).To(Equal(""))
+		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("f", false)]).To(Equal(""))
 	})
 }
 

--- a/controllers/pod_controller_test.go
+++ b/controllers/pod_controller_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -20,9 +19,9 @@ var podStub = corev1.Pod{
 		Name:      "test-pod",
 		Namespace: "default",
 		Annotations: map[string]string{
-			fmt.Sprintf(AnnotationOriginalInitImageTemplate, "a"): "alpine",
-			fmt.Sprintf(AnnotationOriginalImageTemplate, "b"):     "nginx",
-			fmt.Sprintf(AnnotationOriginalImageTemplate, "c"):     "busybox",
+			registry.ContainerAnnotationKey("a", true):  "alpine",
+			registry.ContainerAnnotationKey("b", false): "nginx",
+			registry.ContainerAnnotationKey("c", false): "busybox",
 		},
 		Labels: map[string]string{
 			LabelImageRewrittenName: "true",

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"crypto/sha1"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -131,4 +132,17 @@ func RepositoryLabel(repositoryName string) string {
 	}
 
 	return sanitizedName
+}
+
+func ContainerAnnotationKey(containerName string, initContainer bool) string {
+	template := "original-image-%s"
+	if initContainer {
+		template = "original-init-image-%s"
+	}
+
+	if len(containerName)+len(template)-2 > 63 {
+		containerName = fmt.Sprintf("%x", sha1.Sum([]byte(containerName)))
+	}
+
+	return fmt.Sprintf(template, containerName)
 }


### PR DESCRIPTION
Closes #143 