### PR TITLE
feat(proxy): allow to configure the proxy bind address

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	kubeconfig         string
+	proxyAddr          string
 	metricsAddr        string
 	rateLimitQPS       int
 	rateLimitBurst     int
@@ -33,6 +34,7 @@ func initFlags() {
 	if err := flag.Set("logtostderr", "true"); err != nil {
 		fmt.Fprint(os.Stderr, "could not enable logging to stderr")
 	}
+	flag.StringVar(&proxyAddr, "bind-address", ":8082", "The address the proxy registry endpoint binds to.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Absolute path to the kubeconfig file")
 	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kube-image-keeper-registry:5000", "The address of the registry where cached images are stored.")
@@ -88,5 +90,5 @@ func main() {
 		panic(fmt.Errorf("could not load root certificate authorities: %s", err))
 	}
 
-	<-proxy.New(k8sClient, metricsAddr, []string(insecureRegistries), rootCAs).Run()
+	<-proxy.New(k8sClient, metricsAddr, []string(insecureRegistries), rootCAs).Run(proxyAddr)
 }

--- a/helm/kube-image-keeper/templates/proxy-daemonset.yaml
+++ b/helm/kube-image-keeper/templates/proxy-daemonset.yaml
@@ -25,6 +25,10 @@ spec:
       {{- if .Values.proxy.priorityClassName }}
       priorityClassName: {{ .Values.proxy.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.proxy.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       securityContext:
         {{- toYaml .Values.proxy.podSecurityContext | nindent 8 }}
       containers:
@@ -34,6 +38,15 @@ spec:
           image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           ports:
+            {{- if .Values.proxy.hostNetwork }}
+            - containerPort: {{ .Values.proxy.hostPort }}
+              hostPort: {{ .Values.proxy.hostPort }}
+              protocol: TCP
+            - containerPort: {{ .Values.proxy.metricsPort }}
+              hostPort: {{ .Values.proxy.metricsPort }}
+              name: metrics
+              protocol: TCP
+            {{- else }}
             - containerPort: 8082
               hostIP: {{ .Values.proxy.hostIp }}
               hostPort: {{ .Values.proxy.hostPort }}
@@ -41,6 +54,7 @@ spec:
             - containerPort: 8080
               name: metrics
               protocol: TCP
+            {{- end }}
           command:
             - registry-proxy
             - -v={{ .Values.proxy.verbosity }}
@@ -56,6 +70,10 @@ spec:
             {{- range .keys }}
             - -root-certificate-authorities=/etc/ssl/certs/registry-certificate-authorities/{{- . }}
             {{- end }}
+            {{- end }}
+            {{- if .Values.proxy.hostNetwork }}
+            - -bind-address={{ .Values.proxy.hostIp }}:{{ .Values.proxy.hostPort }}
+            - -metrics-bind-address={{ .Values.proxy.hostIp }}:{{ .Values.proxy.metricsPort }}
             {{- end }}
           {{- if .Values.rootCertificateAuthorities }}
           {{- with .Values.proxy.env }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -105,10 +105,14 @@ proxy:
     pullPolicy: IfNotPresent
     # -- Proxy image tag. Default chart appVersion
     tag: ""
+  # -- whether to run the proxy daemonset in hostNetwork mode
+  hostNetwork: false
   # -- hostPort used for the proxy pod
   hostPort: 7439
   # -- hostIp used for the proxy pod
   hostIp: "127.0.0.1"
+  # -- metricsPort used for the proxy pod (to expose prometheus metrics)
+  metricsPort: 8080
   # -- Verbosity level for the proxy pod
   verbosity: 1
   # -- Specify secrets to be used when pulling proxy image

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -108,11 +108,11 @@ func (p *Proxy) Serve() *Proxy {
 	return p
 }
 
-func (p *Proxy) Run() chan struct{} {
+func (p *Proxy) Run(proxyAddr string) chan struct{} {
 	p.Serve()
 	finished := make(chan struct{})
 	go func() {
-		if err := p.engine.Run(":8082"); err != nil {
+		if err := p.engine.Run(proxyAddr); err != nil {
 			panic(err)
 		}
 		finished <- struct{}{}


### PR DESCRIPTION
This PR adds the `--bind-address` option to the proxy (defaulting to ":8082").

It is backward compatible and can be used to deploy kube-image-keeper in hostNetwork mode as described in #229 .