### PR TITLE
feat(registry-statefulset): added optional access mode override

### DIFF
--- a/helm/kube-image-keeper/templates/registry-pvc.yaml
+++ b/helm/kube-image-keeper/templates/registry-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if and (eq (include "kube-image-keeper.registry-stateless-mode" .) "false") (.Values.registry.persistence.enabled) (eq .Values.registry.persistence.accessModes "ReadWriteMany") }}
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kube-image-keeper.fullname" . }}-registry-pvc
+spec:
+  accessModes:
+    - {{ .Values.registry.persistence.accessModes }}
+  storageClassName: {{ .Values.registry.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.registry.persistence.size }}
+{{- end }}

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -1,7 +1,7 @@
 {{- if eq (include "kube-image-keeper.registry-stateless-mode" .) "false" }}
 
-{{- if gt (int .Values.registry.replicas) 1 -}}
-{{ fail "registry needs a configured S3 endpoint to enable HA mode (>1 replicas), please enable minio or configure an external S3 endpoint" }}
+{{- if and (gt (int .Values.registry.replicas) 1) (ne .Values.registry.persistence.accessModes "ReadWriteMany") -}}
+{{ fail "registry needs a configured S3 endpoint or a PVC which supports ReadWriteMany to enable HA mode (>1 replicas), please enable minio or configure an external S3 endpoint" }}
 {{- end }}
 
 apiVersion: apps/v1
@@ -11,6 +11,7 @@ metadata:
   labels:
     {{- include "kube-image-keeper.registry-labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.registry.replicas }}
   serviceName: {{ include "kube-image-keeper.fullname" . }}-registry
   selector:
     matchLabels:
@@ -108,7 +109,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- if .Values.registry.persistence.enabled }}
+  {{- if and (.Values.registry.persistence.enabled) (ne .Values.registry.persistence.accessModes "ReadWriteMany") }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -119,5 +120,11 @@ spec:
       resources:
         requests:
           storage: {{ .Values.registry.persistence.size }}
+  {{- end }}
+  {{- if and (.Values.registry.persistence.enabled) (eq .Values.registry.persistence.accessModes "ReadWriteMany") }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "kube-image-keeper.fullname" . }}-registry-pvc
   {{- end }}
 {{- end }}

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -113,7 +113,8 @@ spec:
   - metadata:
       name: data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
+      accessModes:
+        - {{ .Values.registry.persistence.accessModes }}
       storageClassName: {{ .Values.registry.persistence.storageClass }}
       resources:
         requests:

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -202,6 +202,8 @@ registry:
   # -- Number of replicas for the registry pod
   replicas: 1
   persistence:
+    # -- AccessMode for persistent volume
+    accessModes: ReadWriteOnce
     # -- If true, enable persistent storage (ignored when using minio or S3)
     enabled: false
     # -- StorageClass for persistent volume


### PR DESCRIPTION
I've added the ability to override the AccessMode for the PVC on the Registry for situations where you are using a PVC which may support ReadWriteMany (for example for EFS CSI Driver), as described in #245

Closes enix/kube-image-keeper#245