### PR TITLE
build(dockerfile): run go build with mount=type=cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ ENV LD_FLAGS="\
     -X 'github.com/enix/kube-image-keeper/internal/metrics.Revision=${REVISION}' \
     -X 'github.com/enix/kube-image-keeper/internal/metrics.BuildDateTime=BUILD_DATE_TIME'"
 
-RUN BUILD_DATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S") && \
+RUN --mount=type=cache,target="/root/.cache/go-build" \
+    BUILD_DATE_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S") && \
     LD_FLAGS=$(/bin/ash -c "set -o pipefail && echo $LD_FLAGS | sed -e \"s/BUILD_DATE_TIME/$BUILD_DATE_TIME/g\"") && \
     controller-gen object paths="./..." && \
-    go build -a -ldflags="$LD_FLAGS" -o manager cmd/cache/main.go && \
-    go build -a -ldflags="$LD_FLAGS" -o registry-proxy cmd/proxy/main.go
+    go build -ldflags="$LD_FLAGS" -o manager cmd/cache/main.go && \
+    go build -ldflags="$LD_FLAGS" -o registry-proxy cmd/proxy/main.go
 
 FROM alpine:3.17 AS alpine
 


### PR DESCRIPTION
This allows shorter build time by reusing the go build cache and removing the `-a` flag of the `go build` command that *"force rebuilding of packages that are already up-to-date"*. It **may not** improve build time in the CI. On my computer it improved the build time by about **80%**.