### PR TITLE
Feat/repository

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -28,4 +28,13 @@ resources:
   webhooks:
     defaulting: true
     webhookVersion: v1
+- api:
+    crdVersion: v1
+    namespaced: true
+  controller: true
+  domain: enix.io
+  group: kuik
+  kind: Repository
+  path: github.com/enix/kube-image-keeper/api/v1alpha1
+  version: v1alpha1
 version: "3"

--- a/PROJECT
+++ b/PROJECT
@@ -2,7 +2,7 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: kuik.enix.io
+domain: enix.io
 layout:
 - go.kubebuilder.io/v3
 projectName: kube-image-keeper
@@ -12,8 +12,8 @@ resources:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: kuik.enix.io
-  group: kuik.enix.io
+  domain: enix.io
+  group: kuik
   kind: CachedImage
   path: github.com/enix/kube-image-keeper/api/v1alpha1
   version: v1alpha1

--- a/api/v1alpha1/cachedimage_types.go
+++ b/api/v1alpha1/cachedimage_types.go
@@ -31,7 +31,7 @@ type UsedBy struct {
 // CachedImageStatus defines the observed state of CachedImage
 type CachedImageStatus struct {
 	IsCached bool   `json:"isCached,omitempty"`
-	UsedBy   UsedBy `json:"usedBy,omitempty" `
+	UsedBy   UsedBy `json:"usedBy,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/cachedimage_types.go
+++ b/api/v1alpha1/cachedimage_types.go
@@ -12,9 +12,7 @@ type CachedImageSpec struct {
 	// +optional
 	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
 	// +optional
-	Retain               bool     `json:"retain,omitempty"`
-	PullSecretNames      []string `json:"pullSecretNames,omitempty"`
-	PullSecretsNamespace string   `json:"pullSecretsNamespace,omitempty"`
+	Retain bool `json:"retain,omitempty"`
 }
 
 type PodReference struct {

--- a/api/v1alpha1/cachedimage_utils.go
+++ b/api/v1alpha1/cachedimage_utils.go
@@ -1,0 +1,41 @@
+package v1alpha1
+
+import (
+	"context"
+
+	"github.com/distribution/reference"
+	"github.com/enix/kube-image-keeper/internal/registry"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *CachedImage) Repository() (reference.Named, error) {
+	named, err := reference.ParseNormalizedNamed(r.Spec.SourceImage)
+	if err != nil {
+		return nil, err
+	}
+
+	return named, nil
+}
+
+func (r *CachedImage) GetPullSecrets(apiReader client.Reader) ([]corev1.Secret, error) {
+	named, err := r.Repository()
+	if err != nil {
+		return nil, err
+	}
+
+	repository := Repository{}
+	err = apiReader.Get(context.TODO(), types.NamespacedName{Name: registry.SanitizeName(named.Name())}, &repository)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	pullSecrets, err := registry.GetPullSecrets(apiReader, repository.Spec.PullSecretsNamespace, repository.Spec.PullSecretNames)
+	if err != nil {
+		return nil, err
+	}
+
+	return pullSecrets, nil
+}

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -13,11 +13,20 @@ type RepositorySpec struct {
 
 // RepositoryStatus defines the observed state of Repository
 type RepositoryStatus struct {
+	Phase string `json:"phase,omitempty"`
+	//+listType=map
+	//+listMapKey=type
+	//+patchStrategy=merge
+	//+patchMergeKey=type
+	//+optional
+	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster,shortName=repo
+//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Repository is the Schema for the repositories API
 type Repository struct {

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -6,7 +6,9 @@ import (
 
 // RepositorySpec defines the desired state of Repository
 type RepositorySpec struct {
-	Name string `json:"name"`
+	Name                 string   `json:"name"`
+	PullSecretNames      []string `json:"pullSecretNames,omitempty"`
+	PullSecretsNamespace string   `json:"pullSecretsNamespace,omitempty"`
 }
 
 // RepositoryStatus defines the observed state of Repository

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -1,0 +1,40 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RepositorySpec defines the desired state of Repository
+type RepositorySpec struct {
+	Name string `json:"name"`
+}
+
+// RepositoryStatus defines the observed state of Repository
+type RepositoryStatus struct {
+}
+
+//+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster,shortName=repo
+
+// Repository is the Schema for the repositories API
+type Repository struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   RepositorySpec   `json:"spec,omitempty"`
+	Status RepositoryStatus `json:"status,omitempty"`
+}
+
+//+kubebuilder:object:root=true
+
+// RepositoryList contains a list of Repository
+type RepositoryList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []Repository `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&Repository{}, &RepositoryList{})
+}

--- a/api/v1alpha1/repository_types.go
+++ b/api/v1alpha1/repository_types.go
@@ -13,7 +13,8 @@ type RepositorySpec struct {
 
 // RepositoryStatus defines the observed state of Repository
 type RepositoryStatus struct {
-	Phase string `json:"phase,omitempty"`
+	Images int    `json:"images,omitempty"`
+	Phase  string `json:"phase,omitempty"`
 	//+listType=map
 	//+listMapKey=type
 	//+patchStrategy=merge
@@ -26,6 +27,7 @@ type RepositoryStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster,shortName=repo
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase"
+//+kubebuilder:printcolumn:name="Images",type="string",JSONPath=".status.images"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Repository is the Schema for the repositories API

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -113,6 +113,13 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "CachedImage")
 		os.Exit(1)
 	}
+	if err = (&controllers.RepositoryReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Repository")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	err = mgr.Add(&kuikenixiov1.PodInitializer{Client: mgr.GetClient()})

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	kuikenixiov1 "github.com/enix/kube-image-keeper/api/v1"
-	kuikenixiov1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
 	"github.com/enix/kube-image-keeper/controllers"
 	"github.com/enix/kube-image-keeper/internal"
 	"github.com/enix/kube-image-keeper/internal/registry"
@@ -109,7 +109,7 @@ func main() {
 		ProxyPort:    proxyPort,
 	}
 	mgr.GetWebhookServer().Register("/mutate-core-v1-pod", &webhook.Admission{Handler: &imageRewriter})
-	if err = (&kuikenixiov1alpha1.CachedImage{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&kuikv1alpha1.CachedImage{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "CachedImage")
 		os.Exit(1)
 	}

--- a/config/crd/bases/kuik.enix.io_cachedimages.yaml
+++ b/config/crd/bases/kuik.enix.io_cachedimages.yaml
@@ -56,12 +56,6 @@ spec:
               expiresAt:
                 format: date-time
                 type: string
-              pullSecretNames:
-                items:
-                  type: string
-                type: array
-              pullSecretsNamespace:
-                type: string
               retain:
                 type: boolean
               sourceImage:

--- a/config/crd/bases/kuik.enix.io_repositories.yaml
+++ b/config/crd/bases/kuik.enix.io_repositories.yaml
@@ -21,6 +21,9 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.images
+      name: Images
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -129,6 +132,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              images:
+                type: integer
               phase:
                 type: string
             type: object

--- a/config/crd/bases/kuik.enix.io_repositories.yaml
+++ b/config/crd/bases/kuik.enix.io_repositories.yaml
@@ -17,7 +17,14 @@ spec:
     singular: repository
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Repository is the Schema for the repositories API
@@ -50,6 +57,80 @@ spec:
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/kuik.enix.io_repositories.yaml
+++ b/config/crd/bases/kuik.enix.io_repositories.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.11.1
+  creationTimestamp: null
+  name: repositories.kuik.enix.io
+spec:
+  group: kuik.enix.io
+  names:
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    shortNames:
+    - repo
+    singular: repository
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the repositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              name:
+                type: string
+            required:
+            - name
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/kuik.enix.io_repositories.yaml
+++ b/config/crd/bases/kuik.enix.io_repositories.yaml
@@ -39,6 +39,12 @@ spec:
             properties:
               name:
                 type: string
+              pullSecretNames:
+                items:
+                  type: string
+                type: array
+              pullSecretsNamespace:
+                type: string
             required:
             - name
             type: object

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,17 +3,20 @@
 # It should be run by config/default
 resources:
 - bases/kuik.enix.io_cachedimages.yaml
+- bases/kuik.enix.io_repositories.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge: []
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_cachedimages.yaml
+#- patches/webhook_in_repositories.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_cachedimages.yaml
+#- patches/cainjection_in_repositories.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/cainjection_in_repositories.yaml
+++ b/config/crd/patches/cainjection_in_repositories.yaml
@@ -1,0 +1,7 @@
+# The following patch adds a directive for certmanager to inject CA into the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: repositories.kuik.enix.io

--- a/config/crd/patches/webhook_in_repositories.yaml
+++ b/config/crd/patches/webhook_in_repositories.yaml
@@ -1,0 +1,16 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: repositories.kuik.enix.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/rbac/repository_editor_role.yaml
+++ b/config/rbac/repository_editor_role.yaml
@@ -1,0 +1,31 @@
+# permissions for end users to edit repositories.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: repository-editor-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: kube-image-keeper
+    app.kubernetes.io/part-of: kube-image-keeper
+    app.kubernetes.io/managed-by: kustomize
+  name: repository-editor-role
+rules:
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories/status
+  verbs:
+  - get

--- a/config/rbac/repository_viewer_role.yaml
+++ b/config/rbac/repository_viewer_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to view repositories.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/instance: repository-viewer-role
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: kube-image-keeper
+    app.kubernetes.io/part-of: kube-image-keeper
+    app.kubernetes.io/managed-by: kustomize
+  name: repository-viewer-role
+rules:
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories/status
+  verbs:
+  - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,3 +72,29 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kuik.enix.io
+  resources:
+  - repositories/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/samples/kuik_v1alpha1_repository.yaml
+++ b/config/samples/kuik_v1alpha1_repository.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuik.enix.io/v1alpha1
+kind: Repository
+metadata:
+  labels:
+    app.kubernetes.io/name: repository
+    app.kubernetes.io/instance: repository-sample
+    app.kubernetes.io/part-of: kube-image-keeper
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: kube-image-keeper
+  name: repository-sample
+spec:
+  # TODO(user): Add fields here

--- a/controllers/collector.go
+++ b/controllers/collector.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strconv"
 
-	kuikenixiov1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
 	kuikMetrics "github.com/enix/kube-image-keeper/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +70,7 @@ func RegisterMetrics(client client.Client) {
 	)
 }
 
-func cachedImagesWithLabelValues(gaugeVec *prometheus.GaugeVec, cachedImage *kuikenixiov1alpha1.CachedImage) prometheus.Gauge {
+func cachedImagesWithLabelValues(gaugeVec *prometheus.GaugeVec, cachedImage *kuikv1alpha1.CachedImage) prometheus.Gauge {
 	return gaugeVec.WithLabelValues(strconv.FormatBool(cachedImage.Status.IsCached), strconv.FormatBool(cachedImage.Spec.ExpiresAt != nil))
 }
 
@@ -83,7 +83,7 @@ func (c *ControllerCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *ControllerCollector) Collect(ch chan<- prometheus.Metric) {
-	cachedImageList := &kuikenixiov1alpha1.CachedImageList{}
+	cachedImageList := &kuikv1alpha1.CachedImageList{}
 	if err := c.List(context.Background(), cachedImageList); err == nil {
 		cachedImageGaugeVec := prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/controllers/pod_controller.go
+++ b/controllers/pod_controller.go
@@ -158,7 +158,7 @@ func (r *PodReconciler) podsWithDeletingCachedImages(obj client.Object) []ctrl.R
 	cachedImage := obj.(*kuikv1alpha1.CachedImage)
 	var currentCachedImage kuikv1alpha1.CachedImage
 	// wait for the CachedImage to be really deleted
-	if err := r.Get(context.Background(), types.NamespacedName{Name: cachedImage.Name}, &currentCachedImage); err == nil || !apierrors.IsNotFound(err) {
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(cachedImage), &currentCachedImage); err == nil || !apierrors.IsNotFound(err) {
 		return make([]ctrl.Request, 0)
 	}
 
@@ -179,8 +179,7 @@ func (r *PodReconciler) podsWithDeletingCachedImages(obj client.Object) []ctrl.R
 			if cachedImage.Spec.SourceImage == value {
 				log.Info("image in use", "pod", pod.Namespace+"/"+pod.Name)
 				res := make([]ctrl.Request, 1)
-				res[0].Name = pod.Name
-				res[0].Namespace = pod.Namespace
+				res[0].NamespacedName = client.ObjectKeyFromObject(&pod)
 				return res
 			}
 		}

--- a/controllers/pod_controller_test.go
+++ b/controllers/pod_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/enix/kube-image-keeper/api/v1alpha1"
-	kuikenixiov1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
 	"github.com/enix/kube-image-keeper/internal/registry"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -75,13 +75,13 @@ func TestDesiredCachedImages(t *testing.T) {
 			name: "basic",
 			pod:  podStub,
 			cachedImages: []v1alpha1.CachedImage{
-				{Spec: kuikenixiov1alpha1.CachedImageSpec{
+				{Spec: kuikv1alpha1.CachedImageSpec{
 					SourceImage: "nginx",
 				}},
-				{Spec: kuikenixiov1alpha1.CachedImageSpec{
+				{Spec: kuikv1alpha1.CachedImageSpec{
 					SourceImage: "busybox",
 				}},
-				{Spec: kuikenixiov1alpha1.CachedImageSpec{
+				{Spec: kuikv1alpha1.CachedImageSpec{
 					SourceImage: "alpine",
 				}},
 			},
@@ -169,7 +169,7 @@ var _ = Describe("Pod Controller", func() {
 		podStubNotRewritten.ResourceVersion = ""
 
 		By("Deleting all cached images")
-		Expect(k8sClient.DeleteAllOf(context.Background(), &kuikenixiov1alpha1.CachedImage{})).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(context.Background(), &kuikv1alpha1.CachedImage{})).Should(Succeed())
 	})
 
 	Context("Pod with containers and init containers", func() {
@@ -177,8 +177,8 @@ var _ = Describe("Pod Controller", func() {
 			By("Creating a pod")
 			Expect(k8sClient.Create(context.Background(), &podStub)).Should(Succeed())
 
-			fetched := &kuikenixiov1alpha1.CachedImageList{}
-			Eventually(func() []kuikenixiov1alpha1.CachedImage {
+			fetched := &kuikv1alpha1.CachedImageList{}
+			Eventually(func() []kuikv1alpha1.CachedImage {
 				_ = k8sClient.List(context.Background(), fetched)
 				return fetched.Items
 			}, timeout, interval).Should(HaveLen(len(podStub.Spec.Containers) + len(podStub.Spec.InitContainers)))
@@ -196,8 +196,8 @@ var _ = Describe("Pod Controller", func() {
 			By("Deleting previously created pod")
 			Expect(k8sClient.Delete(context.Background(), &podStub)).Should(Succeed())
 
-			Eventually(func() []kuikenixiov1alpha1.CachedImage {
-				expiringCachedImages := []kuikenixiov1alpha1.CachedImage{}
+			Eventually(func() []kuikv1alpha1.CachedImage {
+				expiringCachedImages := []kuikv1alpha1.CachedImage{}
 				_ = k8sClient.List(context.Background(), fetched)
 				for _, cachedImage := range fetched.Items {
 					if cachedImage.Spec.ExpiresAt != nil {
@@ -211,8 +211,8 @@ var _ = Describe("Pod Controller", func() {
 			By("Creating a pod without rewriting images")
 			Expect(k8sClient.Create(context.Background(), &podStubNotRewritten)).Should(Succeed())
 
-			fetched := &kuikenixiov1alpha1.CachedImageList{}
-			Eventually(func() []kuikenixiov1alpha1.CachedImage {
+			fetched := &kuikv1alpha1.CachedImageList{}
+			Eventually(func() []kuikv1alpha1.CachedImage {
 				_ = k8sClient.List(context.Background(), fetched)
 				return fetched.Items
 			}, timeout, interval).Should(HaveLen(0))
@@ -224,8 +224,8 @@ var _ = Describe("Pod Controller", func() {
 			podStub.Spec.ServiceAccountName = serviceAccountStub.Name
 			Expect(k8sClient.Create(context.Background(), &podStub)).Should(Succeed())
 
-			fetched := &kuikenixiov1alpha1.CachedImageList{}
-			Eventually(func() []kuikenixiov1alpha1.CachedImage {
+			fetched := &kuikv1alpha1.CachedImageList{}
+			Eventually(func() []kuikv1alpha1.CachedImage {
 				_ = k8sClient.List(context.Background(), fetched)
 				return fetched.Items
 			}, timeout, interval).Should(HaveLen(len(podStub.Spec.Containers) + len(podStub.Spec.InitContainers)))

--- a/controllers/repository_controller.go
+++ b/controllers/repository_controller.go
@@ -1,0 +1,46 @@
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+)
+
+// RepositoryReconciler reconciles a Repository object
+type RepositoryReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=kuik.enix.io,resources=repositories,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kuik.enix.io,resources=repositories/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kuik.enix.io,resources=repositories/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the Repository object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	_ = log.FromContext(ctx)
+
+	// TODO(user): your logic here
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kuikv1alpha1.Repository{}).
+		Complete(r)
+}

--- a/controllers/repository_controller.go
+++ b/controllers/repository_controller.go
@@ -3,12 +3,27 @@ package controllers
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+)
+
+const (
+	repositoryFinalizerName = "repository.kuik.enix.io/finalizer"
+	typeReadyRepository     = "Ready"
 )
 
 // RepositoryReconciler reconciles a Repository object
@@ -31,16 +46,138 @@ type RepositoryReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	log := log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	var repository kuikv1alpha1.Repository
+	if err := r.Get(ctx, req.NamespacedName, &repository); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log.Info("reconciling repository")
+
+	if !repository.ObjectMeta.DeletionTimestamp.IsZero() {
+		r.UpdateStatus(ctx, &repository, []metav1.Condition{{
+			Type:    typeReadyRepository,
+			Status:  metav1.ConditionFalse,
+			Reason:  "AskedForDeletion",
+			Message: "Repository has been asked to be deleted",
+		}})
+
+		if controllerutil.ContainsFinalizer(&repository, repositoryFinalizerName) {
+			var cachedImageList kuikv1alpha1.CachedImageList
+			if err := r.List(ctx, &cachedImageList, client.MatchingFields{repositoryOwnerKey: repository.Name}); err != nil && !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+
+			log.Info("repository is deleting", "cachedImages", len(cachedImageList.Items))
+			if len(cachedImageList.Items) > 0 {
+				return ctrl.Result{}, nil
+			}
+
+			log.Info("removing finalizer")
+			controllerutil.RemoveFinalizer(&repository, repositoryFinalizerName)
+			if err := r.Update(ctx, &repository); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	err := r.UpdateStatus(ctx, &repository, []metav1.Condition{{
+		Type:    typeReadyRepository,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Created",
+		Message: "Repository is ready",
+	}})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Add finalizer to keep the Repository during image removal from registry on deletion
+	if !controllerutil.ContainsFinalizer(&repository, repositoryFinalizerName) {
+		log.Info("adding finalizer")
+		controllerutil.AddFinalizer(&repository, repositoryFinalizerName)
+		if err := r.Update(ctx, &repository); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
 	return ctrl.Result{}, nil
 }
 
+func (r *RepositoryReconciler) UpdateStatus(ctx context.Context, repository *kuikv1alpha1.Repository, conditions []metav1.Condition) error {
+	log := log.FromContext(ctx)
+
+	for _, condition := range conditions {
+		meta.SetStatusCondition(&repository.Status.Conditions, condition)
+	}
+
+	conditionReady := meta.FindStatusCondition(repository.Status.Conditions, typeReadyRepository)
+	if conditionReady.Status == metav1.ConditionTrue {
+		repository.Status.Phase = "Ready"
+	} else if conditionReady.Status == metav1.ConditionFalse {
+		repository.Status.Phase = "Terminating"
+	} else {
+		repository.Status.Phase = ""
+	}
+
+	if err := r.Status().Update(ctx, repository); err != nil {
+		log.Error(err, "Failed to update Repository status")
+		return err
+	}
+
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *RepositoryReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	p := predicate.Funcs{
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+	}
+
+	// Create an index to list CachedImage by Repository
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &kuikv1alpha1.CachedImage{}, repositoryOwnerKey, func(rawObj client.Object) []string {
+		cachedImage := rawObj.(*kuikv1alpha1.CachedImage)
+
+		owners := cachedImage.GetOwnerReferences()
+		for _, owner := range owners {
+			if owner.APIVersion != kuikv1alpha1.GroupVersion.String() || owner.Kind != "Repository" {
+				return nil
+			}
+
+			return []string{owner.Name}
+		}
+
+		return []string{}
+	}); err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuikv1alpha1.Repository{}).
+		Watches(
+			&source.Kind{Type: &kuikv1alpha1.CachedImage{}},
+			handler.EnqueueRequestsFromMapFunc(r.repositoryWithDeletingCachedImages),
+			builder.WithPredicates(p),
+		).
 		Complete(r)
+}
+
+func (r *RepositoryReconciler) repositoryWithDeletingCachedImages(obj client.Object) []ctrl.Request {
+	cachedImage := obj.(*kuikv1alpha1.CachedImage)
+	var currentCachedImage kuikv1alpha1.CachedImage
+	// wait for the CachedImage to be really deleted
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(cachedImage), &currentCachedImage); err == nil || !apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	repositoryName, ok := cachedImage.Labels[kuikv1alpha1.RepositoryLabelName]
+	if !ok {
+		return nil
+	}
+
+	return []ctrl.Request{{NamespacedName: types.NamespacedName{Name: repositoryName}}}
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,7 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kuikenixiov1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
 	"github.com/enix/kube-image-keeper/internal/registry"
 	//+kubebuilder:scaffold:imports
 )
@@ -119,7 +119,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = kuikenixiov1alpha1.AddToScheme(scheme.Scheme)
+	err = kuikv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = corev1.AddToScheme(scheme.Scheme)

--- a/helm/kube-image-keeper/templates/cachedimage-crd.yaml
+++ b/helm/kube-image-keeper/templates/cachedimage-crd.yaml
@@ -53,12 +53,6 @@ spec:
               expiresAt:
                 format: date-time
                 type: string
-              pullSecretNames:
-                items:
-                  type: string
-                type: array
-              pullSecretsNamespace:
-                type: string
               retain:
                 type: boolean
               sourceImage:
@@ -92,10 +86,4 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 {{- end -}}

--- a/helm/kube-image-keeper/templates/clusterrole.yaml
+++ b/helm/kube-image-keeper/templates/clusterrole.yaml
@@ -78,6 +78,32 @@ rules:
     - get
     - patch
     - update
+  - apiGroups:
+    - kuik.enix.io
+    resources:
+    - repositories
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - kuik.enix.io
+    resources:
+    - repositories/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - kuik.enix.io
+    resources:
+    - repositories/status
+    verbs:
+    - get
+    - patch
+    - update
   {{- if .Values.psp.create }}
   - apiGroups:
     - policy

--- a/helm/kube-image-keeper/templates/repository-crd.yaml
+++ b/helm/kube-image-keeper/templates/repository-crd.yaml
@@ -14,7 +14,14 @@ spec:
     singular: repository
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Status
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Repository is the Schema for the repositories API
@@ -47,6 +54,80 @@ spec:
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              phase:
+                type: string
             type: object
         type: object
     served: true

--- a/helm/kube-image-keeper/templates/repository-crd.yaml
+++ b/helm/kube-image-keeper/templates/repository-crd.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.installCRD -}}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: repositories.kuik.enix.io
+spec:
+  group: kuik.enix.io
+  names:
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    shortNames:
+    - repo
+    singular: repository
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the repositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              name:
+                type: string
+            required:
+            - name
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end -}}

--- a/helm/kube-image-keeper/templates/repository-crd.yaml
+++ b/helm/kube-image-keeper/templates/repository-crd.yaml
@@ -36,6 +36,12 @@ spec:
             properties:
               name:
                 type: string
+              pullSecretNames:
+                items:
+                  type: string
+                type: array
+              pullSecretsNamespace:
+                type: string
             required:
             - name
             type: object

--- a/helm/kube-image-keeper/templates/repository-crd.yaml
+++ b/helm/kube-image-keeper/templates/repository-crd.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Status
       type: string
+    - jsonPath: .status.images
+      name: Images
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -126,6 +129,8 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              images:
+                type: integer
               phase:
                 type: string
             type: object

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -260,7 +260,7 @@ func (p *Proxy) getCachedImage(registryDomain string, repositoryName string) (*k
 }
 
 func (p *Proxy) getKeychains(cachedImage *kuikv1alpha1.CachedImage) ([]authn.Keychain, error) {
-	pullSecrets, err := registry.GetPullSecrets(p.k8sClient, cachedImage.Spec.PullSecretsNamespace, cachedImage.Spec.PullSecretNames)
+	pullSecrets, err := cachedImage.GetPullSecrets(p.k8sClient)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -10,7 +10,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	kuikenixiov1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -19,7 +19,7 @@ func NewScheme() *runtime.Scheme {
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(kuikenixiov1alpha1.AddToScheme(scheme))
+	utilruntime.Must(kuikv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 
 	return scheme


### PR DESCRIPTION
This adds a `Repository` CRD so `imagePullSecrets` can be configured on a repository basis. It also open the door to new features based on the concept of Repository, such as scanning for new versions of mutable tags (eg. `latest`).