### PR TITLE
feat(chart): configure the garbage collection cronjob image

### DIFF
--- a/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
@@ -22,7 +22,8 @@ spec:
           restartPolicy: Never
           containers:
             - name: kubectl
-              image: bitnami/kubectl
+              image: "{{ .Values.registry.garbageCollection.image.repository }}:{{ .Values.registry.garbageCollection.image.tag }}"
+              imagePullPolicy: {{ .Values.registry.garbageCollection.image.pullPolicy }}
               command:
                 - bash
                 - -c

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -218,6 +218,13 @@ registry:
     schedule: "0 0 * * 0"
     # -- If true, delete untagged manifests. Default to false since there is a known bug in **docker distribution** garbage collect job.
     deleteUntagged: false
+    image:
+      # -- Cronjob image repository
+      repository: bitnami/kubectl
+      # -- Cronjob image pull policy
+      pullPolicy: IfNotPresent
+      # -- Cronjob image tag. Default 'latest'
+      tag: "latest"
   service:
     # -- Registry service type
     type: ClusterIP


### PR DESCRIPTION
Chart : configure docker image for the registry garbage collection cronjob in `values.yaml` .

The default values of `{repository: bitnami/kubectl, tag: "latest"}`  match the existing hardcoded values;
providing a custom docker image for the cronjob should fix #275.