### PR TITLE
Suggestion - Move crd to separate folder

### DIFF
--- a/helm/kube-image-keeper/crds/cachedimage-crd.yaml
+++ b/helm/kube-image-keeper/crds/cachedimage-crd.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.installCRD -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -53,6 +52,12 @@ spec:
               expiresAt:
                 format: date-time
                 type: string
+              pullSecretNames:
+                items:
+                  type: string
+                type: array
+              pullSecretsNamespace:
+                type: string
               retain:
                 type: boolean
               sourceImage:
@@ -86,4 +91,9 @@ spec:
     storage: true
     subresources:
       status: {}
-{{- end -}}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -4,8 +4,6 @@
 
 # -- Delay in days before deleting an unused CachedImage
 cachedImagesExpiryDelay: 30
-# -- If true, install the CRD
-installCRD: true
 # -- List of architectures to put in cache
 architectures: [amd64]
 # -- Insecure registries to allow to cache and proxify images from


### PR DESCRIPTION
I encountered a problem when I install, uninstall and install the helm chart again. Because the crd in the cluster will not be deleted and when you want to reinstall the helm chart the crd and CachedImage objects will be deleted.

So instead of setting the value `installCRD: true` for the reinstall in the values file let helm handle the creation of the crd. 

https://helm.sh/docs/chart_best_practices/custom_resource_definitions/

(I used the crd definition of the 1.6.0 version, thats why you find changes in the crd itself)