### PR TITLE
fix(controller): manually add a decoder since its not injected anymore

### DIFF
--- a/api/core/v1/pod_webhook.go
+++ b/api/core/v1/pod_webhook.go
@@ -37,7 +37,7 @@ type ImageRewriter struct {
 	IgnoreImages           []*regexp.Regexp
 	IgnorePullPolicyAlways bool
 	ProxyPort              int
-	decoder                *admission.Decoder
+	Decoder                *admission.Decoder
 }
 
 type PodInitializer struct {
@@ -56,7 +56,7 @@ func (a *ImageRewriter) Handle(ctx context.Context, req admission.Request) admis
 		WithName("webhook.pod")
 
 	pod := &corev1.Pod{}
-	err := a.decoder.Decode(req, pod)
+	err := a.Decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -104,12 +104,6 @@ func (a *ImageRewriter) RewriteImages(pod *corev1.Pod, isNewPod bool) []Rewritte
 	}
 
 	return rewrittenImages
-}
-
-// InjectDecoder injects the decoder
-func (a *ImageRewriter) InjectDecoder(d *admission.Decoder) error {
-	a.decoder = d
-	return nil
 }
 
 func (a *ImageRewriter) handleContainer(pod *corev1.Pod, container *corev1.Container, annotationKey string, rewriteImage bool) RewrittenImage {

--- a/api/core/v1/pod_webhook_test.go
+++ b/api/core/v1/pod_webhook_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var podStub = corev1.Pod{
@@ -113,20 +112,6 @@ func TestRewriteImagesWithIgnore(t *testing.T) {
 		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("d", false)]).To(Equal("185.145.250.247:30042/alpine"))
 		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("e", false)]).To(Equal(""))
 		g.Expect(podStub.Annotations[registry.ContainerAnnotationKey("f", false)]).To(Equal(""))
-	})
-}
-
-func TestInjectDecoder(t *testing.T) {
-	g := NewWithT(t)
-	t.Run("Inject decoder", func(t *testing.T) {
-		ir := ImageRewriter{}
-		decoder := &admission.Decoder{}
-
-		g.Expect(ir.decoder).To(BeNil())
-		err := ir.InjectDecoder(decoder)
-		g.Expect(err).To(Not(HaveOccurred()))
-		g.Expect(ir.decoder).To(Not(BeNil()))
-		g.Expect(ir.decoder).To(Equal(decoder))
 	})
 }
 

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kuikenixiov1 "github.com/enix/kube-image-keeper/api/core/v1"
 	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
@@ -112,6 +113,7 @@ func main() {
 		IgnoreImages:           ignoreImages,
 		IgnorePullPolicyAlways: ignorePullPolicyAlways,
 		ProxyPort:              proxyPort,
+		Decoder:                admission.NewDecoder(mgr.GetScheme()),
 	}
 	mgr.GetWebhookServer().Register("/mutate-core-v1-pod", &webhook.Admission{Handler: &imageRewriter})
 	if err = (&kuikv1alpha1.CachedImage{}).SetupWebhookWithManager(mgr); err != nil {


### PR DESCRIPTION
Removed in controller-runtime v0.15.0 https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.15.0