### PR TITLE
fix: http connection leak in NewBearer()

### DIFF
--- a/internal/proxy/bearer.go
+++ b/internal/proxy/bearer.go
@@ -39,6 +39,9 @@ func (b *Bearer) GetToken() string {
 
 func NewBearer(endpoint string, path string) (*Bearer, error) {
 	response, err := http.Get(endpoint + path)
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +52,9 @@ func NewBearer(endpoint string, path string) (*Bearer, error) {
 		url := fmt.Sprintf("%s?service=%s&scope=%s", wwwAuthenticate["realm"], wwwAuthenticate["service"], wwwAuthenticate["scope"])
 
 		response, err := http.Get(url)
+		if response != nil && response.Body != nil {
+			defer response.Body.Close()
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -57,8 +63,6 @@ func NewBearer(endpoint string, path string) (*Bearer, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		response.Body.Close()
 	}
 
 	return &bearer, nil


### PR DESCRIPTION
The `response.Body` from the first `http.Get()` call in `NewBearer()` is not closed. This leaks connections to the `registry` server and can result in substantial memory usage, as the registry allocates a 4MB buffer for each connection and neither end enforces an idle timeout.

Fixes #378