### PR TITLE
feat: Add accept-images parameter to whitelist images

### DIFF
--- a/api/core/v1/pod_webhook.go
+++ b/api/core/v1/pod_webhook.go
@@ -35,6 +35,7 @@ var (
 type ImageRewriter struct {
 	Client                 client.Client
 	IgnoreImages           []*regexp.Regexp
+	AcceptImages           []*regexp.Regexp
 	IgnorePullPolicyAlways bool
 	ProxyPort              int
 	Decoder                *admission.Decoder
@@ -167,6 +168,15 @@ func (a *ImageRewriter) isImageRewritable(container *corev1.Container) error {
 		if r.MatchString(container.Image) {
 			return fmt.Errorf("image matches %s", r.String())
 		}
+	}
+
+	if len(a.AcceptImages) > 0 {
+		for _, r := range a.AcceptImages {
+			if r.MatchString(container.Image) {
+				return nil
+			}
+		}
+		return fmt.Errorf("image does not match any existing rules (--accept-images not empty)")
 	}
 
 	return nil

--- a/cmd/cache/main.go
+++ b/cmd/cache/main.go
@@ -39,6 +39,7 @@ func main() {
 	var expiryDelay uint
 	var proxyPort int
 	var ignoreImages internal.RegexpArrayFlags
+	var acceptImages internal.RegexpArrayFlags
 	var ignorePullPolicyAlways bool
 	var architectures internal.ArrayFlags
 	var maxConcurrentCachedImageReconciles int
@@ -52,6 +53,7 @@ func main() {
 	flag.UintVar(&expiryDelay, "expiry-delay", 30, "The delay in days before deleting an unused CachedImage.")
 	flag.IntVar(&proxyPort, "proxy-port", 8082, "The port on which the registry proxy accepts connections on each host.")
 	flag.Var(&ignoreImages, "ignore-images", "Regex that represents images to be excluded (this flag can be used multiple times).")
+	flag.Var(&acceptImages, "accept-images", "Regex that represents images to be whitelisted (this flag can be used multiple times).")
 	flag.BoolVar(&ignorePullPolicyAlways, "ignore-pull-policy-always", true, "Ignore containers that are configured with imagePullPolicy: Always")
 	flag.Var(&architectures, "arch", "Architecture of image to put in cache (this flag can be used multiple times).")
 	flag.StringVar(&registry.Endpoint, "registry-endpoint", "kube-image-keeper-registry:5000", "The address of the registry where cached images are stored.")
@@ -111,6 +113,7 @@ func main() {
 	imageRewriter := kuikenixiov1.ImageRewriter{
 		Client:                 mgr.GetClient(),
 		IgnoreImages:           ignoreImages,
+		AcceptImages:           acceptImages,
 		IgnorePullPolicyAlways: ignorePullPolicyAlways,
 		ProxyPort:              proxyPort,
 		Decoder:                admission.NewDecoder(mgr.GetScheme()),

--- a/helm/kube-image-keeper/templates/controller-deployment.yaml
+++ b/helm/kube-image-keeper/templates/controller-deployment.yaml
@@ -48,6 +48,9 @@ spec:
             {{- range .Values.controllers.webhook.ignoredImages }}
             - -ignore-images={{- . }}
             {{- end }}
+            {{- range .Values.controllers.webhook.acceptedImages }}
+            - -accept-images={{- . }}
+            {{- end }}
             {{- range .Values.architectures }}
             - -arch={{- . }}
             {{- end }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -78,6 +78,8 @@ controllers:
     ignoredNamespaces: []
     # -- Don't enable image caching if the image match the following regexes
     ignoredImages: []
+    # -- Enable image caching only if the image matches the following regexes (only applies when not empty)
+    acceptedImages: []
     # -- Don't enable image caching if the image is configured with imagePullPolicy: Always
     ignorePullPolicyAlways: true
     # -- If true, create the issuer used to issue the webhook certificate


### PR DESCRIPTION
This PR adds a new parameter called --accept-images, which behaves much like the --ignore-images parameter, except it provides a way to specify a whitelist of image regexes to rewrite. This check is done after ignore-images, so one can still specify a blacklist.

Use case: 

- We want to cache public images from certain repos to optimize traffic and performance, without exposing private images. We understand that KEP 2535 will solve this issue in term, but it will only enter alpha stage in v1.32
- The current --ignore-images parameter doesn't do it for us, because Golang's regexp engine doesn't support negative lookaheads (meaning we can't make a whitelist out of this blacklist)
- We have added the --accept-images parameter, which, when it's not empty, will only rewrite images that match regexes (also integrated into the Helm chart)

Example usage (Helm values file):
```
controllers:
  webhook:
    acceptedImages:
    - "^gcr\\.io/.*"
    - "^ghcr\\.io/.*"
    - "^docker\\.io/.*"
    - "^registry\\.k8s\\.io.*"
```

This will cache only images coming from known public repos (provided image names are prefixed with the repo, but that's  a compromise we are willing to accept).