### PR TITLE
fix: Duration doesn't actually support 'd' suffix, warn on negative Duration

### DIFF
--- a/api/kuik/v1alpha1/repository_types.go
+++ b/api/kuik/v1alpha1/repository_types.go
@@ -12,7 +12,7 @@ type RepositorySpec struct {
 	PullSecretNames []string `json:"pullSecretNames,omitempty"`
 	// PullSecretsNamespace is the namespace where pull secrets can be found for CachedImages of this Repository
 	PullSecretsNamespace string `json:"pullSecretsNamespace,omitempty"`
-	// UpdateInterval is the interval in human readable format (1m, 1h, 1d...) at which matched CachedImages from this Repository are updated (see spec.UpdateFilters)
+	// UpdateInterval is the interval in human readable format (1m, 1h...) at which matched CachedImages from this Repository are updated (see spec.UpdateFilters)
 	UpdateInterval *metav1.Duration `json:"updateInterval,omitempty"`
 	// UpdateFilters is a list of regexps that need to match (at least one of them) the .spec.SourceImage of a CachedImage from this Repository to update it at regular interval
 	UpdateFilters []string `json:"updateFilters,omitempty"`

--- a/config/crd/bases/kuik.enix.io_repositories.yaml
+++ b/config/crd/bases/kuik.enix.io_repositories.yaml
@@ -73,8 +73,8 @@ spec:
                 type: array
               updateInterval:
                 description: UpdateInterval is the interval in human readable format
-                  (1m, 1h, 1d...) at which matched CachedImages from this Repository
-                  are updated (see spec.UpdateFilters)
+                  (1m, 1h...) at which matched CachedImages from this Repository are
+                  updated (see spec.UpdateFilters)
                 type: string
             required:
             - name

--- a/helm/kube-image-keeper/crds/repository-crd.yaml
+++ b/helm/kube-image-keeper/crds/repository-crd.yaml
@@ -72,8 +72,8 @@ spec:
                 type: array
               updateInterval:
                 description: UpdateInterval is the interval in human readable format
-                  (1m, 1h, 1d...) at which matched CachedImages from this Repository
-                  are updated (see spec.UpdateFilters)
+                  (1m, 1h...) at which matched CachedImages from this Repository are
+                  updated (see spec.UpdateFilters)
                 type: string
             required:
             - name

--- a/internal/controller/kuik/repository_controller.go
+++ b/internal/controller/kuik/repository_controller.go
@@ -2,6 +2,8 @@ package kuik
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -149,6 +151,9 @@ func (r *RepositoryReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if repository.Spec.UpdateInterval != nil {
+		if repository.Spec.UpdateInterval.Duration <= 0 {
+			return ctrl.Result{}, errors.New(fmt.Sprintf("invalid UpdateInterval: %s", repository.Spec.UpdateInterval.String()))
+		}
 		nextUpdate := repository.Status.LastUpdate.Add(repository.Spec.UpdateInterval.Duration)
 		if time.Now().After(nextUpdate) {
 			log.Info("updating repository")


### PR DESCRIPTION
- fixes #451
- "1d" was among `updateInterval` examples, but `ParseDuration` doesn't support it, remove from doc (*)
- catch and report negative `updateInterval`

(*) This is not supported, because the actual size of a day is not trivial (DST, leap sec...)