### PR TITLE
feat(helm): securityContext for garbage collection pod and container

### DIFF
--- a/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
+++ b/helm/kube-image-keeper/templates/garbage-collection-cron-job.yaml
@@ -32,8 +32,12 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            {{- toYaml .Values.registry.garbageCollection.podSecurityContext | nindent 12 }}
           containers:
             - name: kubectl
+              securityContext:
+                {{- toYaml .Values.registry.garbageCollection.securityContext | nindent 16 }}
               image: "{{ .Values.registry.garbageCollection.image.repository }}:{{ .Values.registry.garbageCollection.image.tag }}"
               resources:
                 {{- toYaml .Values.registry.garbageCollection.resources | nindent 16 }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -239,6 +239,10 @@ registry:
     schedule: "0 0 * * 0"
     # -- If true, delete untagged manifests. Default to false since there is a known bug in **docker distribution** garbage collect job.
     deleteUntagged: false
+    # -- Security context for the garbage collector pod
+    podSecurityContext: {}
+    # -- Security context for containers of the garbage collector pod
+    securityContext: {}
     # -- Specify a nodeSelector for the garbage collector pod
     nodeSelector: {}
     # -- Affinity for the garbage collector pod


### PR DESCRIPTION
This PR adds the ability to add securityContext to the pod and container in the garbage collection CronJob.

Many environments have policies that encourage or enforce specific securityContext to be defined. The garbage collection CronJob seems to be the only pod in the Helm Chart that currently does not support this.