### PR TITLE
Support RBAC and ServiceAccount configuration (fixes #500)

### DIFF
--- a/helm/kube-image-keeper/templates/_helpers.tpl
+++ b/helm/kube-image-keeper/templates/_helpers.tpl
@@ -103,10 +103,32 @@ app.kubernetes.io/component: garbage-collection
 {{- end }}
 
 {{/*
+Create the name of the ClusterRole to use
+*/}}
+{{- define "kube-image-keeper.clusterRoleName" -}}
+{{- printf "%s-%s" (include "kube-image-keeper.fullname" .) "controllers" }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "kube-image-keeper.serviceAccountName" -}}
-{{- default (printf "%s-%s" (include "kube-image-keeper.fullname" .) "controllers") .Values.serviceAccount.name }}
+{{- if .Values.serviceAccount.create -}}
+  {{- default (include "kube-image-keeper.clusterRoleName" .) .Values.serviceAccount.name }}
+{{- else -}}
+  {{- default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Create the name of the registry service account to use
+*/}}
+{{- define "kube-image-keeper.registry-serviceAccountName" -}}
+{{- if .Values.registry.serviceAccount.create -}}
+  {{- default (printf "%s-%s" (include "kube-image-keeper.fullname" .) "registry") .Values.registry.serviceAccount.name }}
+{{- else -}}
+  {{- default "default" .Values.registry.serviceAccount.name }}
+{{- end -}}
 {{- end }}
 
 {{- define "kube-image-keeper.registry-stateless-mode" -}}

--- a/helm/kube-image-keeper/templates/clusterrole.yaml
+++ b/helm/kube-image-keeper/templates/clusterrole.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.rbac.create }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}
 rules:
   - apiGroups:
     - ""
@@ -120,7 +121,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}-leader-election
 rules:
   - apiGroups:
     - ""
@@ -153,3 +154,4 @@ rules:
     verbs:
     - create
     - patch
+{{- end }}

--- a/helm/kube-image-keeper/templates/clusterrolebinding.yaml
+++ b/helm/kube-image-keeper/templates/clusterrolebinding.yaml
@@ -1,11 +1,12 @@
+{{- if .Values.rbac.create }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
@@ -15,12 +16,13 @@ subjects:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}-leader-election
 roleRef:
   kind: ClusterRole
-  name: {{ include "kube-image-keeper.serviceAccountName" . }}-leader-election
+  name: {{ include "kube-image-keeper.clusterRoleName" . }}-leader-election
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "kube-image-keeper.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/kube-image-keeper/templates/registry-deployment.yaml
+++ b/helm/kube-image-keeper/templates/registry-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- if .Values.registry.priorityClassName }}
       priorityClassName: {{ .Values.registry.priorityClassName | quote }}
       {{- end }}
-      serviceAccountName: {{ include "kube-image-keeper.fullname" . }}-registry
+      serviceAccountName: {{ include "kube-image-keeper.registry-serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.registry.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/kube-image-keeper/templates/registry-serviceaccount.yaml
+++ b/helm/kube-image-keeper/templates/registry-serviceaccount.yaml
@@ -1,10 +1,15 @@
+{{- if .Values.registry.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kube-image-keeper.fullname" . }}-registry
+  name: {{ include "kube-image-keeper.registry-serviceAccountName" . }}
   labels:
     {{- include "kube-image-keeper.labels" . | nindent 4 }}
+    {{- with .Values.registry.serviceAccount.extraLabels }}
+    {{- . | toYaml | trim | nindent 4 }}
+    {{- end }}
   {{- with .Values.registry.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/helm/kube-image-keeper/templates/registry-statefulset.yaml
+++ b/helm/kube-image-keeper/templates/registry-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       {{- if .Values.registry.priorityClassName }}
       priorityClassName: {{ .Values.registry.priorityClassName | quote }}
       {{- end }}
-      serviceAccountName: {{ include "kube-image-keeper.fullname" . }}-registry
+      serviceAccountName: {{ include "kube-image-keeper.registry-serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.registry.podSecurityContext | nindent 8 }}
       {{- if .Values.registry.persistence.enabled }}

--- a/helm/kube-image-keeper/templates/serviceaccount.yaml
+++ b/helm/kube-image-keeper/templates/serviceaccount.yaml
@@ -1,10 +1,15 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kube-image-keeper.serviceAccountName" . }}
   labels:
     {{- include "kube-image-keeper.labels" . | nindent 4 }}
+    {{- with .Values.serviceAccount.extraLabels }}
+    {{- . | toYaml | trim | nindent 4 }}
+    {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -324,7 +324,7 @@ registry:
     # -- Maximum unavailable pods
     maxUnavailable: ""
   serviceMonitor:
-    # -- Should a ServiceMonitor object be installed to  scrape kuik registry metrics. For prometheus-operator (kube-prometheus) users.
+    # -- Should a ServiceMonitor object be installed to scrape kuik registry metrics. For prometheus-operator (kube-prometheus) users.
     create: false
     # -- Target scrape interval set in the ServiceMonitor
     scrapeInterval: 60s
@@ -335,8 +335,14 @@ registry:
     # -- Relabel config for the ServiceMonitor, see: https://coreos.com/operators/prometheus/docs/latest/api.html#relabelconfig
     relabelings: []
   serviceAccount:
-    # -- Annotations to add to the servicateAccount
+    # -- Create the registry serviceAccount. If false, use serviceAccount with specified name (or "default" if false and name unset.)
+    create: true
+    # -- Name of the registry serviceAccount (auto-generated if unset and create is true)
+    name: ""
+    # -- Annotations to add to the registry serviceAccount
     annotations: {}
+    # -- Additional labels to add to the registry serviceAccount
+    extraLabels: {}
 
 docker-registry-ui:
   # -- If true, enable the registry user interface
@@ -372,11 +378,19 @@ minio:
         --secret-key "$(cat /opt/bitnami/minio/svcacct/registry/secretKey)"
         provisioning registry) > /dev/null
 
+rbac:
+  # -- Create the ClusterRole and ClusterRoleBinding. If false, need to associate permissions with serviceAccount outside this Helm chart.
+  create: true
+
 serviceAccount:
-  # -- Annotations to add to the servicateAccount
-  annotations: {}
-  # -- Name of the serviceAccount
+  # -- Create the serviceAccount. If false, use serviceAccount with specified name (or "default" if false and name unset.)
+  create: true
+  # -- Name of the serviceAccount (auto-generated if unset and create is true)
   name: ""
+  # -- Annotations to add to the serviceAccount
+  annotations: {}
+  # -- Additional labels to add to the serviceAccount
+  extraLabels: {}
 
 psp:
   # -- If True, create the PodSecurityPolicy

--- a/test/helm_test.go
+++ b/test/helm_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func unmarshal[T any](t *testing.T, data string, obj *T) {
@@ -337,7 +337,7 @@ func TestHelmTemplate(t *testing.T) {
 				"rbac.create":           "false",
 			},
 			assertions: map[string](func(t *testing.T, output string)){
-				"clusterrole.yaml": nil,
+				"clusterrole.yaml":        nil,
 				"clusterrolebinding.yaml": nil,
 				"controller-deployment.yaml": makeAssertion(func(t *testing.T, obj *appsv1.Deployment) {
 					assert := assert.New(t)
@@ -359,11 +359,11 @@ func TestHelmTemplate(t *testing.T) {
 					require.Len(t, obj.Spec.Template.Spec.Containers, 1)
 					assert.Equal(obj.Spec.Template.Spec.ServiceAccountName, "serviceaccount123")
 				}),
-				"clusterrole.yaml": makeAssertion(func (t *testing.T, obj *rbacv1.ClusterRole) {
+				"clusterrole.yaml": makeAssertion(func(t *testing.T, obj *rbacv1.ClusterRole) {
 					assert := assert.New(t)
 					assert.Equal(obj.ObjectMeta.Name, "custom-fullname-controllers")
 				}),
-				"clusterrolebinding.yaml": makeAssertion(func (t *testing.T, obj *rbacv1.ClusterRoleBinding) {
+				"clusterrolebinding.yaml": makeAssertion(func(t *testing.T, obj *rbacv1.ClusterRoleBinding) {
 					assert := assert.New(t)
 					assert.Equal(obj.ObjectMeta.Name, "custom-fullname-controllers")
 					assert.Equal(obj.RoleRef.Name, "custom-fullname-controllers")
@@ -387,8 +387,8 @@ func TestHelmTemplate(t *testing.T) {
 		{
 			name: "Use s3 backend, disable registry ServiceAccount creation (using custom registry ServiceAccount name)",
 			values: map[string]string{
-				"registry.serviceAccount.create":               "false",
-				"registry.serviceAccount.name":                 "serviceaccount123",
+				"registry.serviceAccount.create":                "false",
+				"registry.serviceAccount.name":                  "serviceaccount123",
 				"registry.serviceAccount.persistence.s3.region": "us-west-2",
 				"registry.serviceAccount.persistence.s3.bucket": "kuik-image-cache",
 			},

--- a/test/helm_test.go
+++ b/test/helm_test.go
@@ -400,6 +400,31 @@ func TestHelmTemplate(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name: "Add custom labels and annotations to serviceAccount and registry serviceAccount",
+			values: map[string]string{
+				"serviceAccount.create":                      "true",
+				"serviceAccount.annotations.custom":          "abc",
+				"serviceAccount.extraLabels.foo":             "bar",
+				"registry.serviceAccount.create":             "true",
+				"registry.serviceAccount.annotations.custom": "def",
+				"registry.serviceAccount.extraLabels.baz":    "qux",
+			},
+			assertions: map[string](func(t *testing.T, output string)){
+				"serviceaccount.yaml": makeAssertion(func(t *testing.T, obj *v1.ServiceAccount) {
+					assert := assert.New(t)
+					assert.Equal(obj.ObjectMeta.Annotations["custom"], "abc")
+					assert.Equal(obj.ObjectMeta.Labels["foo"], "bar")
+					assert.Equal(obj.ObjectMeta.Labels["app.kubernetes.io/name"], "kube-image-keeper")
+				}),
+				"registry-serviceaccount.yaml": makeAssertion(func(t *testing.T, obj *v1.ServiceAccount) {
+					assert := assert.New(t)
+					assert.Equal(obj.ObjectMeta.Annotations["custom"], "def")
+					assert.Equal(obj.ObjectMeta.Labels["baz"], "qux")
+					assert.Equal(obj.ObjectMeta.Labels["app.kubernetes.io/name"], "kube-image-keeper")
+				}),
+			},
+		},
 	}
 
 	releaseName := "kube-image-keeper"


### PR DESCRIPTION
Allow users to control RBAC and ServiceAccount creation through Helm, per https://v3-1-0.helm.sh/docs/chart_best_practices/rbac/