### PR TITLE
Allow complex environment variables in manager configuration

### DIFF
--- a/helm/kube-image-keeper/templates/manager-deployment.yaml
+++ b/helm/kube-image-keeper/templates/manager-deployment.yaml
@@ -51,9 +51,8 @@ spec:
             - -unused-image-ttl={{ .Values.unusedImageTTL }}
           env:
             # custom environment variables
-            {{- range .Values.manager.env }}
-            - name: {{ .name }}
-              value: {{ .value }}
+            {{- with .Values.manager.env }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Allow complex environment variables in manager configuration. This allows more easily setting GOMAXPROCS/GOMEMLIMIT variables dynamically. This is presumed to be a breaking change given the current pattern. This is inconsistently present in 1.14.0 as well, where the proxy uses this format, and the controller uses the [name:value, ... ] array method.

For example:
```yaml
    env:
      - name: GOMEMLIMIT
        valueFrom:
          resourceFieldRef:
            resource: limits.memory
      - name: GOMAXPROCS
        valueFrom:
          resourceFieldRef:
            resource: limits.cpu
```