### PR TITLE
fix(webhook): bound goroutines and add timeout in clearStaleMirrorStatus

### DIFF
--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -106,6 +106,9 @@ configuration:
   routing:
     activeCheck:
       timeout: 1s
+      staleMirrorCleanup:
+        maxConcurrent: 10
+        timeout: 5s
     rewriteOnNeverImagePullPolicy: false
   monitoring:
     registries:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,13 @@ type Routing struct {
 }
 
 type ActiveCheck struct {
-	Timeout time.Duration `koanf:"timeout"`
+	Timeout            time.Duration      `koanf:"timeout"`
+	StaleMirrorCleanup StaleMirrorCleanup `koanf:"staleMirrorCleanup"`
+}
+
+type StaleMirrorCleanup struct {
+	MaxConcurrent int           `koanf:"maxConcurrent"`
+	Timeout       time.Duration `koanf:"timeout"`
 }
 
 type Monitoring struct {
@@ -52,6 +58,10 @@ var defaultConfig = Config{
 	Routing: Routing{
 		ActiveCheck: ActiveCheck{
 			Timeout: time.Second,
+			StaleMirrorCleanup: StaleMirrorCleanup{
+				MaxConcurrent: 10,
+				Timeout:       5 * time.Second,
+			},
 		},
 		RewriteOnNeverImagePullPolicy: false,
 	},

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -60,6 +60,7 @@ func SetupPodWebhookWithManager(mgr ctrl.Manager, d *PodCustomDefaulter) error {
 	d.checkCache = checkCache
 	d.alternativeCache = alternativeCache
 	d.requestGroup = &singleflight.Group{}
+	d.cleanupSemaphore = make(chan struct{}, d.Config.Routing.ActiveCheck.StaleMirrorCleanup.MaxConcurrent)
 
 	return ctrl.NewWebhookManagedBy(mgr, &corev1.Pod{}).
 		WithDefaulter(d).
@@ -80,6 +81,7 @@ type PodCustomDefaulter struct {
 	checkCache       otter.Cache[string, bool]
 	alternativeCache otter.Cache[string, *cachedAlternativeImage]
 	requestGroup     *singleflight.Group
+	cleanupSemaphore chan struct{}
 }
 
 type AlternativeImage struct {
@@ -530,7 +532,7 @@ func (d *PodCustomDefaulter) checkImageAvailabilityCached(ctx context.Context, i
 		d.checkCache.Set(image.Reference, err == nil)
 
 		if result == kuikv1alpha1.ImageAvailabilityNotFound && image.SecretOwner != nil {
-			go d.clearStaleMirrorStatus(image)
+			d.tryCleanupStaleMirrorStatus(ctx, image)
 		}
 
 		return err, nil
@@ -543,10 +545,34 @@ func (d *PodCustomDefaulter) checkImageAvailabilityCached(ctx context.Context, i
 	return nil
 }
 
+// tryCleanupStaleMirrorStatus attempts to launch clearStaleMirrorStatus in a
+// bounded goroutine. Returns a channel that is closed when the goroutine
+// finishes, or nil if the semaphore was full and the cleanup was dropped.
+//
+// Dropped cleanups are not retried here; the next availability check on the
+// same reference will hit this path again (no positive cache entry is stored
+// for NotFound results), so the status will eventually reconcile.
+func (d *PodCustomDefaulter) tryCleanupStaleMirrorStatus(parentCtx context.Context, image *AlternativeImage) <-chan struct{} {
+	select {
+	case d.cleanupSemaphore <- struct{}{}:
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			defer func() { <-d.cleanupSemaphore }()
+			ctx, cancel := context.WithTimeout(context.WithoutCancel(parentCtx), d.Config.Routing.ActiveCheck.StaleMirrorCleanup.Timeout)
+			defer cancel()
+			d.clearStaleMirrorStatus(ctx, image)
+		}()
+		return done
+	default:
+		podlog.V(1).Info("cleanup semaphore full, skipping stale mirror status clear", "reference", image.Reference)
+		return nil
+	}
+}
+
 // clearStaleMirrorStatus clears the mirroredAt field on the ISM/CISM status entry
 // matching the given mirror reference. This signals the controller to re-mirror the image.
-func (d *PodCustomDefaulter) clearStaleMirrorStatus(image *AlternativeImage) {
-	ctx := context.Background()
+func (d *PodCustomDefaulter) clearStaleMirrorStatus(ctx context.Context, image *AlternativeImage) {
 	log := podlog.WithValues("reference", image.Reference)
 
 	ism, ok := image.SecretOwner.(*kuikv1alpha1.ImageSetMirror)

--- a/internal/webhook/core/v1/pod_webhook_test.go
+++ b/internal/webhook/core/v1/pod_webhook_test.go
@@ -1,13 +1,17 @@
 package v1
 
 import (
+	"context"
 	"slices"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	"github.com/enix/kube-image-keeper/internal/config"
 	corev1 "k8s.io/api/core/v1"
-	// TODO (user): Add any additional imports if needed
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Pod Webhook", func() {
@@ -169,5 +173,69 @@ var _ = Describe("compareAlternatives", func() {
 				"first", "second", "third",
 			}))
 		})
+	})
+})
+
+var _ = Describe("clearStaleMirrorStatus", func() {
+	It("should respect context cancellation", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+
+		d := &PodCustomDefaulter{Client: k8sClient}
+		image := &AlternativeImage{
+			Reference: "mirror.example.com/cache/library/nginx:latest",
+			SecretOwner: &kuikv1alpha1.ImageSetMirror{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ism", Namespace: "default"},
+				Status: kuikv1alpha1.ImageSetMirrorStatus{
+					MatchingImages: []kuikv1alpha1.MatchingImage{
+						{
+							Image: "docker.io/library/nginx:latest",
+							Mirrors: []kuikv1alpha1.MirrorStatus{
+								{Image: "mirror.example.com/cache/library/nginx:latest", MirroredAt: &metav1.Time{Time: time.Now()}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		d.clearStaleMirrorStatus(ctx, image)
+		// Should return quickly without hanging (context is already cancelled)
+	})
+
+	It("should drop cleanup when semaphore is full", func() {
+		sem := make(chan struct{}, 1)
+		// Fill the semaphore
+		sem <- struct{}{}
+
+		image := &AlternativeImage{
+			Reference:   "mirror.example.com/cache/library/nginx:latest",
+			SecretOwner: &kuikv1alpha1.ImageSetMirror{},
+		}
+
+		d := &PodCustomDefaulter{
+			Client: k8sClient,
+			Config: &config.Config{
+				Routing: config.Routing{
+					ActiveCheck: config.ActiveCheck{
+						StaleMirrorCleanup: config.StaleMirrorCleanup{
+							Timeout: time.Second,
+						},
+					},
+				},
+			},
+			cleanupSemaphore: sem,
+		}
+
+		By("Returning nil when the semaphore is full")
+		Expect(d.tryCleanupStaleMirrorStatus(context.Background(), image)).To(BeNil())
+
+		By("Freeing the semaphore")
+		<-sem
+
+		By("Launching and completing the cleanup")
+		done := d.tryCleanupStaleMirrorStatus(context.Background(), image)
+		Expect(done).NotTo(BeNil())
+		Eventually(done, 2*time.Second).Should(BeClosed())
 	})
 })

--- a/internal/webhook/core/v1/webhook_suite_test.go
+++ b/internal/webhook/core/v1/webhook_suite_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/enix/kube-image-keeper/internal/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -92,7 +93,10 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = SetupPodWebhookWithManager(mgr, &PodCustomDefaulter{Client: mgr.GetClient()})
+	testConfig, err := config.LoadDefault()
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupPodWebhookWithManager(mgr, &PodCustomDefaulter{Client: mgr.GetClient(), Config: testConfig})
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:webhook


### PR DESCRIPTION
> `clearStaleMirrorStatus` now accepts a context with a 30s timeout (detached from the webhook request via `context.WithoutCancel`) instead of using context.Background(). A semaphore (capacity 10) prevents unbounded goroutine accumulation when the API server is slow.

This issue was found and fixed using Claude Opus 4.6. I reviewed it already and found it interesting, however I'm not sure if we should hardcode the semaphore capacity, make it configurable, or maybe that we don't even want to use a semaphore?

IMHO, the use of a semaphore is a good idea. It could be improved using a queue, but then we could face a OOM if too much requests are sent. Maybe a semaphore is good enough. I also maybe would lower the default timeout to `5s` make both configurable.