### PR TITLE
fix(mirroring): keep original image in use for rewritten pods

### DIFF
--- a/internal/controller/kuik/clusterimagesetmirror_controller_test.go
+++ b/internal/controller/kuik/clusterimagesetmirror_controller_test.go
@@ -7,6 +7,7 @@ import (
 	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -164,6 +165,125 @@ var _ = Describe("ClusterImageSetMirror Controller", func() {
 			Expect(resource.Status.MatchingImages).To(HaveLen(1))
 			Expect(resource.Status.MatchingImages[0].UnusedSince).NotTo(BeNil())
 			Expect(resource.Status.MatchingImages[0].UnusedSince.Time).To(BeTemporally("==", firstUnusedSince))
+		})
+	})
+
+	// Regression coverage for commit d26a099: the reconciler must match its
+	// ImageFilter against the pod's current (rewritten) image, not the
+	// original image stashed in the kuik.enix.io/original-images annotation.
+	Context("When a pod's image has been rewritten by the webhook", func() {
+		const (
+			resourceName   = "test-rewritten-cluster"
+			podName        = "rewritten-pod-cluster"
+			namespace      = "default"
+			originalImage  = "docker.io/library/nginx:1.25"
+			rewrittenImage = "rewritten.example.com/library/nginx:1.25"
+			mirrorRegistry = "mirror.example.com"
+			mirrorPath     = "cache"
+			expectedMirror = "mirror.example.com/cache/library/nginx:1.25"
+		)
+
+		ctx := context.Background()
+		typeNamespacedName := types.NamespacedName{Name: resourceName}
+		podNamespacedName := types.NamespacedName{Name: podName, Namespace: namespace}
+
+		newClusterReconciler := func() *ClusterImageSetMirrorReconciler {
+			return &ClusterImageSetMirrorReconciler{
+				ImageSetMirrorBaseReconciler: ImageSetMirrorBaseReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				},
+			}
+		}
+
+		createRewrittenPod := func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						OriginalImagesAnnotation: `{"app":"` + originalImage + `"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: rewrittenImage},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			DeferCleanup(func() {
+				p := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podNamespacedName, p); err == nil {
+					_ = k8sClient.Delete(ctx, p)
+				}
+			})
+		}
+
+		createCISM := func(filterInclude []string) {
+			resource := &kuikv1alpha1.ClusterImageSetMirror{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Finalizers: []string{imageSetMirrorFinalizer},
+				},
+				Spec: kuikv1alpha1.ClusterImageSetMirrorSpec{
+					ImageFilter: kuikv1alpha1.ImageFilterDefinition{Include: filterInclude},
+					Mirrors:     kuikv1alpha1.Mirrors{{Registry: mirrorRegistry, Path: mirrorPath}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+			DeferCleanup(func() {
+				res := &kuikv1alpha1.ClusterImageSetMirror{}
+				if err := k8sClient.Get(ctx, typeNamespacedName, res); err == nil {
+					res.Finalizers = nil
+					_ = k8sClient.Update(ctx, res)
+					_ = k8sClient.Delete(ctx, res)
+				}
+			})
+		}
+
+		It("matches the pod's rewritten image when the filter includes the rewritten registry", func() {
+			createRewrittenPod()
+			createCISM([]string{`rewritten\.example\.com/.*`})
+
+			By("Pre-seeding status so the mirror loop skips actual image copies")
+			resource := &kuikv1alpha1.ClusterImageSetMirror{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+			mirroredAt := metav1.NewTime(time.Now())
+			resource.Status.MatchingImages = []kuikv1alpha1.MatchingImage{{
+				Image: rewrittenImage,
+				Mirrors: []kuikv1alpha1.MirrorStatus{
+					{Image: expectedMirror, MirroredAt: &mirroredAt},
+				},
+			}}
+			Expect(k8sClient.Status().Update(ctx, resource)).To(Succeed())
+
+			By("Reconciling")
+			_, err := newClusterReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the rewritten image stays in matchingImages and is not marked unused")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+			Expect(resource.Status.MatchingImages).To(HaveLen(1))
+			Expect(resource.Status.MatchingImages[0].Image).To(Equal(rewrittenImage))
+			Expect(resource.Status.MatchingImages[0].UnusedSince).To(BeNil())
+		})
+
+		It("does not match the pod when only the original (pre-rewrite) image matches the filter", func() {
+			createRewrittenPod()
+			createCISM([]string{`docker\.io/library/nginx:.*`})
+
+			By("Reconciling with an empty status (nothing seeded)")
+			_, err := newClusterReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the original image was not picked up as a matching image")
+			resource := &kuikv1alpha1.ClusterImageSetMirror{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, resource)).To(Succeed())
+			for _, mi := range resource.Status.MatchingImages {
+				Expect(mi.Image).NotTo(Equal(originalImage))
+			}
+			Expect(resource.Status.MatchingImages).To(BeEmpty())
 		})
 	})
 })

--- a/internal/controller/kuik/clusterimagesetmirror_controller_test.go
+++ b/internal/controller/kuik/clusterimagesetmirror_controller_test.go
@@ -286,4 +286,116 @@ var _ = Describe("ClusterImageSetMirror Controller", func() {
 			Expect(resource.Status.MatchingImages).To(BeEmpty())
 		})
 	})
+
+	// Regression coverage for https://github.com/enix/kube-image-keeper/issues/567.
+	// Scenario: the upstream A registry is unreachable, so the webhook has
+	// rewritten pod-2 to pull from mirror B. pod-1 (which pinned the original
+	// A reference) is gone. The CISM status was populated earlier with the
+	// original A image and its B mirror; that entry must not be marked unused
+	// while pod-2 still depends on the mirror copy.
+	Context("Issue #567: CISM must keep the original image in use when pods reference only the mirror", func() {
+		const (
+			resourceName   = "test-issue-567-cism"
+			podName        = "issue-567-rewritten-pod"
+			namespace      = "default"
+			originalImage  = "a.example.com/test/foo:v1"
+			mirrorRegistry = "b.example.com"
+			rewrittenImage = "b.example.com/test/foo:v1"
+		)
+
+		ctx := context.Background()
+		typeNamespacedName := types.NamespacedName{Name: resourceName}
+		podNamespacedName := types.NamespacedName{Name: podName, Namespace: namespace}
+
+		newClusterReconciler := func() *ClusterImageSetMirrorReconciler {
+			return &ClusterImageSetMirrorReconciler{
+				ImageSetMirrorBaseReconciler: ImageSetMirrorBaseReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				},
+			}
+		}
+
+		It("keeps unusedSince nil on the original image while a rewritten pod uses the mirror copy", func() {
+			By("Creating pod-2 rewritten by the webhook (container image = mirror URL, annotation = original URL)")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						OriginalImagesAnnotation: `{"app":"` + originalImage + `"}`,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: rewrittenImage},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			DeferCleanup(func() {
+				p := &corev1.Pod{}
+				if err := k8sClient.Get(ctx, podNamespacedName, p); err == nil {
+					_ = k8sClient.Delete(ctx, p)
+				}
+			})
+
+			By("Creating a CISM whose filter targets the ORIGINAL registry A and whose mirror is B")
+			cism := &kuikv1alpha1.ClusterImageSetMirror{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       resourceName,
+					Finalizers: []string{imageSetMirrorFinalizer},
+				},
+				Spec: kuikv1alpha1.ClusterImageSetMirrorSpec{
+					ImageFilter: kuikv1alpha1.ImageFilterDefinition{
+						Include: []string{`a\.example\.com/.*`},
+					},
+					Mirrors: kuikv1alpha1.Mirrors{
+						{Registry: mirrorRegistry},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cism)).To(Succeed())
+			DeferCleanup(func() {
+				res := &kuikv1alpha1.ClusterImageSetMirror{}
+				if err := k8sClient.Get(ctx, typeNamespacedName, res); err == nil {
+					res.Finalizers = nil
+					_ = k8sClient.Update(ctx, res)
+					_ = k8sClient.Delete(ctx, res)
+				}
+			})
+
+			By("Pre-seeding status as it would be after pod-1 mirrored the image — original image + already-mirrored B copy")
+			Expect(k8sClient.Get(ctx, typeNamespacedName, cism)).To(Succeed())
+			mirroredAt := metav1.NewTime(time.Now())
+			cism.Status.MatchingImages = []kuikv1alpha1.MatchingImage{
+				{
+					Image: originalImage,
+					Mirrors: []kuikv1alpha1.MirrorStatus{
+						{Image: rewrittenImage, MirroredAt: &mirroredAt},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, cism)).To(Succeed())
+
+			By("Reconciling after pod-1 has been deleted and only the rewritten pod-2 remains")
+			_, err := newClusterReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the original image is still tracked and has not been marked unused")
+			got := &kuikv1alpha1.ClusterImageSetMirror{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, got)).To(Succeed())
+
+			var matching *kuikv1alpha1.MatchingImage
+			for i := range got.Status.MatchingImages {
+				if got.Status.MatchingImages[i].Image == originalImage {
+					matching = &got.Status.MatchingImages[i]
+					break
+				}
+			}
+			Expect(matching).NotTo(BeNil(), "original image must remain in status.matchingImages")
+			Expect(matching.UnusedSince).To(BeNil(),
+				"unusedSince must stay nil while pod-2 still pulls from the mirror (issue #567)")
+		})
+	})
 })

--- a/internal/controller/kuik/commonimagesetmirror.go
+++ b/internal/controller/kuik/commonimagesetmirror.go
@@ -156,7 +156,8 @@ func mergePreviousAndCurrentMatchingImages(ctx context.Context, pods []corev1.Po
 		}
 	}
 
-	if err := updateUnusedSince(ctx, matchingImagesMap, ismStatus, imageFilter); err != nil {
+	inUseImages := podsInUseImages(ctx, pods)
+	if err := updateUnusedSince(ctx, matchingImagesMap, inUseImages, ismStatus, imageFilter); err != nil {
 		return nil, err
 	}
 
@@ -247,7 +248,23 @@ func normalizedImageNamesFromPod(pod *corev1.Pod) iter.Seq[string] {
 	return maps.Keys(imageNames)
 }
 
-func updateUnusedSince(ctx context.Context, matchingImagesMap map[string]kuikv1alpha1.MatchingImage, ismStatus *kuikv1alpha1.ImageSetMirrorStatus, imageFilter filter.Filter) error {
+// podsInUseImages returns the set of normalized image names that are still
+// referenced by the cluster, considering BOTH the current container image and
+// the original image stashed in the kuik.enix.io/original-images annotation.
+// This is the signal used to decide whether a previously-mirrored image is
+// still in use: a pod that the webhook has rewritten to pull from the mirror
+// still logically requires its original reference.
+func podsInUseImages(ctx context.Context, pods []corev1.Pod) map[string]struct{} {
+	inUse := map[string]struct{}{}
+	for i := range pods {
+		for image := range normalizedImageNamesFromAnnotatedPod(ctx, &pods[i]) {
+			inUse[image] = struct{}{}
+		}
+	}
+	return inUse
+}
+
+func updateUnusedSince(ctx context.Context, matchingImagesMap map[string]kuikv1alpha1.MatchingImage, inUseImages map[string]struct{}, ismStatus *kuikv1alpha1.ImageSetMirrorStatus, imageFilter filter.Filter) error {
 	log := logf.FromContext(ctx)
 	unusedSinceNotMatching := metav1.Time{Time: (time.Time{}).Add(time.Hour)}
 
@@ -265,7 +282,7 @@ func updateUnusedSince(ctx context.Context, matchingImagesMap map[string]kuikv1a
 				img.UnusedSince = &unusedSinceNotMatching
 				log.Info("image is not matching anymore, queuing it for deletion", "image", img.Image)
 			}
-		} else if _, ok := matchingImagesMap[named.String()]; !ok {
+		} else if _, ok := inUseImages[named.String()]; !ok {
 			if img.UnusedSince.IsZero() {
 				img.UnusedSince = &metav1.Time{Time: time.Now()}
 				log.Info("image is not used anymore, marking it as unused", "image", img.Image)

--- a/internal/controller/kuik/commonimagesetmirror_test.go
+++ b/internal/controller/kuik/commonimagesetmirror_test.go
@@ -1,0 +1,83 @@
+package kuik
+
+import (
+	"context"
+	"slices"
+
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// These tests guard the behavior fixed in commit d26a099: when the webhook has
+// rewritten a pod's image (original A -> current B), the mirror controllers
+// (ImageSetMirror / ClusterImageSetMirror) must match their filters against
+// B (the current image actually in the spec), not A (the original image
+// stored in the kuik.enix.io/original-images annotation).
+var _ = Describe("Mirror controllers match on rewritten, not original image", func() {
+	const (
+		originalImage  = "docker.io/library/nginx:1.25"
+		rewrittenImage = "rewritten.example.com/library/nginx:1.25"
+	)
+
+	ctx := context.Background()
+
+	newRewrittenPod := func() corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rewritten-pod",
+				Namespace: "default",
+				Annotations: map[string]string{
+					OriginalImagesAnnotation: `{"app":"` + originalImage + `"}`,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app", Image: rewrittenImage},
+				},
+			},
+		}
+	}
+
+	Context("normalizedImageNamesFromPod (used by the mirror reconcilers)", func() {
+		It("returns only the rewritten container image", func() {
+			pod := newRewrittenPod()
+			got := slices.Collect(normalizedImageNamesFromPod(&pod))
+			Expect(got).To(ConsistOf(rewrittenImage))
+			Expect(got).NotTo(ContainElement(originalImage))
+		})
+	})
+
+	Context("normalizedImageNamesFromAnnotatedPod (used by the availability reconciler)", func() {
+		It("returns both the current and the original image, so availability is tracked for both", func() {
+			pod := newRewrittenPod()
+			got := slices.Collect(normalizedImageNamesFromAnnotatedPod(ctx, &pod))
+			Expect(got).To(ConsistOf(rewrittenImage, originalImage))
+		})
+	})
+
+	Context("podsByNormalizedMatchingImages (mirror matching logic)", func() {
+		It("matches the pod on the rewritten image when the filter includes it", func() {
+			f := kuikv1alpha1.ImageFilterDefinition{
+				Include: []string{`rewritten\.example\.com/.*`},
+			}.MustBuild()
+
+			pods := []corev1.Pod{newRewrittenPod()}
+			got := podsByNormalizedMatchingImages(ctx, f, nil, pods)
+			Expect(got).To(HaveKey(rewrittenImage))
+			Expect(got).NotTo(HaveKey(originalImage))
+		})
+
+		It("does not match the pod when only the original (pre-rewrite) image matches the filter", func() {
+			f := kuikv1alpha1.ImageFilterDefinition{
+				Include: []string{`docker\.io/library/nginx:.*`},
+			}.MustBuild()
+
+			pods := []corev1.Pod{newRewrittenPod()}
+			got := podsByNormalizedMatchingImages(ctx, f, nil, pods)
+			Expect(got).To(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/kuik/commonimagesetmirror_test.go
+++ b/internal/controller/kuik/commonimagesetmirror_test.go
@@ -11,11 +11,123 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// These tests guard the behavior fixed in commit d26a099: when the webhook has
-// rewritten a pod's image (original A -> current B), the mirror controllers
-// (ImageSetMirror / ClusterImageSetMirror) must match their filters against
-// B (the current image actually in the spec), not A (the original image
-// stored in the kuik.enix.io/original-images annotation).
+// Regression tests for https://github.com/enix/kube-image-keeper/issues/567.
+//
+// Scenario: two registries, A (upstream) and B (mirror). After an image is
+// mirrored to B and becomes unavailable on A, the webhook rewrites new pods'
+// container.Image from A/... to B/.... Those pods still carry the original
+// A/... reference in the kuik.enix.io/original-images annotation.
+//
+// The mirror reconcilers must still treat the original A/... image as "in
+// use" for as long as such a rewritten pod exists; otherwise updateUnusedSince
+// marks the image unused and the cleanup loop eventually deletes it from B,
+// breaking new pulls.
+var _ = Describe("Issue #567: rewritten pods keep the original image in use", func() {
+	const (
+		originalImage  = "a.example.com/test/foo:v1"
+		rewrittenImage = "b.example.com/test/foo:v1"
+		mirrorPrefix   = "b.example.com"
+	)
+
+	ctx := context.Background()
+
+	newRewrittenPod := func(name string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Annotations: map[string]string{
+					OriginalImagesAnnotation: `{"app":"` + originalImage + `"}`,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "app", Image: rewrittenImage},
+				},
+			},
+		}
+	}
+
+	Context("podsInUseImages (the decoupled in-use signal)", func() {
+		It("returns the original image for a rewritten pod, so existing mirror entries stay alive", func() {
+			pods := []corev1.Pod{newRewrittenPod("pod-2")}
+			got := podsInUseImages(ctx, pods)
+
+			// Both names must appear; updateUnusedSince keys off the original
+			// reference stored in the annotation to avoid marking the mirrored
+			// image as unused while the rewritten pod still needs it.
+			Expect(got).To(HaveKey(originalImage))
+			Expect(got).To(HaveKey(rewrittenImage))
+		})
+	})
+
+	Context("mergePreviousAndCurrentMatchingImages", func() {
+		It("leaves unusedSince nil for the original image while a rewritten pod still references it", func() {
+			spec := &kuikv1alpha1.ImageSetMirrorSpec{
+				ImageFilter: kuikv1alpha1.ImageFilterDefinition{
+					Include: []string{`a\.example\.com/.*`},
+				},
+				Mirrors: kuikv1alpha1.Mirrors{
+					{Registry: "b.example.com"},
+				},
+			}
+
+			// Prior reconciliation (when pod-1 was still around, unrewritten)
+			// already recorded the original image in the status.
+			status := &kuikv1alpha1.ImageSetMirrorStatus{
+				MatchingImages: []kuikv1alpha1.MatchingImage{
+					{
+						Image: originalImage,
+						Mirrors: []kuikv1alpha1.MirrorStatus{
+							{Image: rewrittenImage},
+						},
+					},
+				},
+			}
+
+			// pod-1 (unrewritten) is gone; only pod-2 (rewritten to B) remains.
+			pods := []corev1.Pod{newRewrittenPod("pod-2")}
+			mirrorPrefixes := map[string][]string{"": {mirrorPrefix}}
+
+			_, err := mergePreviousAndCurrentMatchingImages(ctx, pods, spec, status, mirrorPrefixes)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(status.MatchingImages).To(HaveLen(1))
+			Expect(status.MatchingImages[0].Image).To(Equal(originalImage))
+			Expect(status.MatchingImages[0].UnusedSince).To(BeNil(),
+				"unusedSince must stay nil while a rewritten pod still needs the mirrored image")
+		})
+
+		It("does not add the original image to matchingImages on a fresh CISM (mirroring is driven by the current image only)", func() {
+			// The two concerns are decoupled: rewritten pods must keep an
+			// EXISTING mirror entry alive (covered above), but must NOT create
+			// new mirror entries for the original reference — only the current
+			// container image drives what gets mirrored (d26a099).
+			spec := &kuikv1alpha1.ImageSetMirrorSpec{
+				ImageFilter: kuikv1alpha1.ImageFilterDefinition{
+					Include: []string{`a\.example\.com/.*`},
+				},
+				Mirrors: kuikv1alpha1.Mirrors{
+					{Registry: "b.example.com"},
+				},
+			}
+			status := &kuikv1alpha1.ImageSetMirrorStatus{}
+			pods := []corev1.Pod{newRewrittenPod("pod-2")}
+			mirrorPrefixes := map[string][]string{"": {mirrorPrefix}}
+
+			_, err := mergePreviousAndCurrentMatchingImages(ctx, pods, spec, status, mirrorPrefixes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status.MatchingImages).To(BeEmpty())
+		})
+	})
+})
+
+// These tests guard the behavior fixed in commit d26a099: when the webhook
+// has rewritten a pod's image (original A -> current B), the mirror
+// reconcilers must match their filters against B (the current image actually
+// in the spec), not A (the original image stored in the
+// kuik.enix.io/original-images annotation). The "still in use" signal is
+// decoupled and covered separately (see issue #567 regression tests).
 var _ = Describe("Mirror controllers match on rewritten, not original image", func() {
 	const (
 		originalImage  = "docker.io/library/nginx:1.25"
@@ -50,8 +162,8 @@ var _ = Describe("Mirror controllers match on rewritten, not original image", fu
 		})
 	})
 
-	Context("normalizedImageNamesFromAnnotatedPod (used by the availability reconciler)", func() {
-		It("returns both the current and the original image, so availability is tracked for both", func() {
+	Context("normalizedImageNamesFromAnnotatedPod (used by the availability reconciler and the in-use signal)", func() {
+		It("returns both the current and the original image", func() {
 			pod := newRewrittenPod()
 			got := slices.Collect(normalizedImageNamesFromAnnotatedPod(ctx, &pod))
 			Expect(got).To(ConsistOf(rewrittenImage, originalImage))


### PR DESCRIPTION
## Summary

- Decouples "what to mirror" from "what is still in use" in the CISM/ISM cleanup path. Mirror source selection keeps the behavior from `d26a099` (driven by the pod's current container image), but `updateUnusedSince` now keys its in-use check off a broader signal that also considers the `kuik.enix.io/original-images` annotation.
- Fixes the regression described in #567: after the webhook rewrites a pod's `container.Image` to the mirror URL (because the upstream registry is gone), the CISM/ISM controllers no longer mark the corresponding mirrored image as unused, so `cleanup.retention` no longer deletes images that rewritten pods still depend on.

## Implementation notes

- New helper `podsInUseImages` in `internal/controller/kuik/commonimagesetmirror.go` returns the union of current container images and annotated originals.
- `updateUnusedSince` now takes an `inUseImages` set alongside `matchingImagesMap`; "is it still used?" is decided against the broader set, while mirroring targets continue to be driven by `matchingImagesMap`.
- No change to `podsByNormalizedMatchingImages` or to the CISM/ISM pod watchers; mirror source selection stays on the current image (`normalizedImageNamesFromPod`), preserving `d26a099`'s intent.

Closes #567