### PR TITLE
fix: add namespace templating to all namespaced resources

### DIFF
--- a/helm/kube-image-keeper/templates/manager-configmap.yaml
+++ b/helm/kube-image-keeper/templates/manager-configmap.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-manager-config
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
     {{- .Values.configuration | toYaml | nindent 4 }}

--- a/helm/kube-image-keeper/templates/manager-deployment.yaml
+++ b/helm/kube-image-keeper/templates/manager-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-image-keeper.manager-labels" . | nindent 4 }}
 spec:

--- a/helm/kube-image-keeper/templates/manager-metrics-service.yaml
+++ b/helm/kube-image-keeper/templates/manager-metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-manager-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-image-keeper.manager-labels" . | nindent 4 }}
 spec:

--- a/helm/kube-image-keeper/templates/manager-poddisruptionbudget.yaml
+++ b/helm/kube-image-keeper/templates/manager-poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-image-keeper.manager-labels" . | nindent 4 }}
 spec:

--- a/helm/kube-image-keeper/templates/manager-servicemonitor.yaml
+++ b/helm/kube-image-keeper/templates/manager-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-image-keeper.manager-labels" . | nindent 4 }}
     {{- with .Values.manager.serviceMonitor.extraLabels }}

--- a/helm/kube-image-keeper/templates/serviceaccount.yaml
+++ b/helm/kube-image-keeper/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kube-image-keeper.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-image-keeper.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.extraLabels }}

--- a/helm/kube-image-keeper/templates/webhook-certificate.yaml
+++ b/helm/kube-image-keeper/templates/webhook-certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-serving-cert
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
   - {{ include "kube-image-keeper.fullname" . }}-webhook.{{ .Release.Namespace }}.svc
@@ -20,6 +21,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 {{- end -}}

--- a/helm/kube-image-keeper/templates/webhook-service.yaml
+++ b/helm/kube-image-keeper/templates/webhook-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kube-image-keeper.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443


### PR DESCRIPTION
useful when using helmfile with argocd

helmfile runs helm template under the hood, which doesn't add the namespace to resources. when argocd applies it afterwards those resources end up in default namespace