### PR TITLE
CodeRabbit + AGENTS.md

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,137 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+
+# CodeRabbit configuration. The GitHub App reads this on every PR.
+# Docs: https://docs.coderabbit.ai/configuration/
+
+language: en-US
+
+chat:
+  # Replies to "@coderabbitai" comments without a leading slash command.
+  auto_reply: true
+
+# Style cadre applied to every review.
+tone_instructions: |
+  Be concise and technical. No promotional content, no references to
+  CodeRabbit features in comments, no suggestions to upgrade tier or
+  invite collaborators.
+
+reviews:
+  # 'chill' = friendly, suggests improvements; 'assertive' = nitpickier.
+  # Chill is the right default for a small team — assertive generates a
+  # lot of style noise that drowns the actually-useful findings.
+  profile: chill
+
+  # Don't request changes on the PR — leave merge gating to humans + CI.
+  # CodeRabbit flags issues as comments; the reviewer decides what blocks.
+  request_changes_workflow: false
+
+  # Top-level summary at the start of each review (the "Walkthrough"
+  # block). Useful for skim-reading what changed without opening every
+  # file diff.
+  high_level_summary: true
+
+  # No poems / no ASCII art. Keep the reviews professional.
+  poem: false
+
+  # Status posted as a check at the bottom of the PR.
+  review_status: true
+
+  # Auto-review every new PR (including from forks). Set drafts:false
+  # so we don't burn budget on WIP branches.
+  auto_review:
+    enabled: true
+    drafts: false
+    # Skip Dependabot's bot PRs — bumps are mechanical, the diff is
+    # just a version number change, and CodeRabbit has nothing useful
+    # to say. Same for semantic-release commits that only edit version
+    # metadata.
+    ignore_title_keywords:
+      - "build(deps):"
+      - "ci(deps):"
+      - "chore(deps):"
+      - "chore(release):"
+
+  # Auto-generated files: don't waste tokens reviewing them, the source
+  # of truth is elsewhere.
+  #   - zz_generated.deepcopy.go: produced by `make generate` (controller-gen)
+  #   - config/crd/bases & helm crds: produced by `make manifests`
+  #     (the helm copy is a verbatim mirror of config/crd/bases)
+  #   - helm clusterrole-*.yaml: sliced out of config/rbac by the Makefile
+  path_filters:
+    - "!api/kuik/v1alpha1/zz_generated.deepcopy.go"
+    - "!config/crd/bases/**"
+    - "!helm/kube-image-keeper/crds/**"
+    - "!helm/kube-image-keeper/files/clusterrole-rules.yaml"
+    - "!helm/kube-image-keeper/files/clusterrole-leader-elec-rules.yaml"
+    - "!cover.out"
+    - "!go.sum"
+
+  # Per-path guidance fed to the model alongside the diff. Keep these
+  # short and load-bearing — long instructions get diluted.
+  path_instructions:
+    - path: "internal/webhook/**/*.go"
+      instructions: |
+        This is the mutating admission webhook that rewrites Pod images
+        on CREATE — it sits in the critical path of every Pod admission
+        in the cluster. Treat it as security- and availability-critical:
+        flag anything that could panic, leak goroutines, block on a slow
+        registry call without honoring the configured timeout, or bypass
+        the `original-images` annotation guard (which prevents
+        re-processing). Be strict about error handling on the admission
+        response — returning an error fails Pod admission cluster-wide.
+
+    - path: "internal/registry/**/*.go"
+      instructions: |
+        Registry interaction via go-containerregistry. Pull-secret
+        credentials and TLS settings flow through here — flag any
+        unchecked input, credential logging, or path that could
+        misclassify a registry status (Available / NotFound /
+        Unreachable / InvalidAuth / QuotaExceeded). The status
+        classification feeds the webhook's failover logic, so a wrong
+        verdict reroutes user traffic.
+
+    - path: "internal/controller/**/*.go"
+      instructions: |
+        controller-runtime reconcilers. Flag missing requeue on
+        transient errors, status updates that race with spec changes
+        (always re-read before patching status), and any reconcile path
+        that can hot-loop. Owner references and finalizers must be set
+        consistently with the rest of the codebase.
+
+    - path: "api/kuik/v1alpha1/**/*.go"
+      instructions: |
+        CRD type definitions. Removed or renamed fields are breaking
+        for existing users; call them out explicitly.
+
+    - path: "**/*.go"
+      instructions: |
+        Go code for a Kubernetes operator (kubebuilder v4,
+        controller-runtime). Tests live next to the code (*_test.go)
+        and use Ginkgo/Gomega with envtest. Prefer idiomatic Go and
+        the patterns already in the file over introducing new
+        abstractions. New code should always be tested.
+
+    - path: "helm/kube-image-keeper/**/*.{yaml,tpl}"
+      instructions: |
+        Helm chart for the operator. Flag changes that break upgrades
+        from a previous chart version (renamed values, removed
+        defaults, changed selector labels on the Deployment or
+        webhook Service), and any RBAC widening beyond what the
+        controller and webhook strictly need. The chart README is
+        generated from `README.md.gotmpl` via helm-docs — don't ask
+        for hand-edits to a generated README.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Flag unpinned actions (`@v4` instead of `@<sha>`), missing
+        `permissions:` blocks, and overly broad `GITHUB_TOKEN` scopes.
+        Action versions are managed by Dependabot (see
+        `.github/dependabot.yml`) — don't suggest floating tags.
+
+    - path: "docs/**"
+      instructions: |
+        User-facing documentation. Any change to webhook routing
+        behaviour, CRD fields, priority semantics, or config defaults
+        must be reflected here. Flag code changes whose docs were
+        not updated in the same PR (see "Change Discipline" in
+        AGENTS.md).

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -1,4 +1,5 @@
 min_version: 1.7.0
+skip_lfs: true
 
 pre-commit:
   piped: true
@@ -11,6 +12,17 @@ pre-commit:
       run: make lint-fix
       glob: "**/*.go"
       stage_fixed: true
+    - name: markdownlint
+      run: npx --yes markdownlint-cli2 --fix -- {staged_files}
+      glob: "**/*.md"
+      stage_fixed: true
+      # markdownlint-cli2 requires Node.js >= 20. Skip when Node is
+      # missing or older — keeps the hook optional for contributors
+      # who only touch Go code and don't have a Node toolchain.
+      skip:
+        - run: |
+            ! command -v node || 
+            [ $(node -v | cut -d'.' -f1 | tr -d 'v') -lt 20 ]
 
 pre-push:
   jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,4 +111,4 @@ Any code change that adds, modifies, or removes behaviour must be accompanied by
 
 ## Git Hooks
 
-Lefthook runs `make manifests generate lint-fix` on pre-commit and `make test` on pre-push; conventional commits are enforced. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Lefthook runs `make manifests generate lint-fix` and `markdownlint-cli2` (the latter skipped unless Node.js ≥ 20 is available) on pre-commit, and `make test` on pre-push; conventional commits are enforced. See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md
+
+This file provides guidance for AI coding agents (Claude Code, Cursor, Aider, OpenAI Codex CLI, etc.) when working with code in this repository.
+
+## Project Overview
+
+kube-image-keeper (kuik) v2 is a Kubernetes operator providing container image routing, mirroring, and replication. Built with Go and Kubebuilder v4 (controller-runtime). It intercepts Pod creation via a mutating webhook and rewrites container images to the first available alternative from a prioritized list defined via CRDs.
+
+## Common Commands
+
+The Makefile is the source of truth — run `make help` for the full list. A few non-obvious things:
+
+- `go test ./internal/controller/kuik -run TestName -v` — run a single unit test
+- `make test-e2e` needs a running Kind cluster (see [`docs/development.md`](docs/development.md))
+
+## Documentation
+
+The `docs/` directory contains user-facing documentation that is also useful for understanding the codebase:
+
+- [`docs/crds.md`](docs/crds.md) — CRD reference with all fields and semantics
+- [`docs/image-routing.md`](docs/image-routing.md) — deep dive into the priority system and webhook routing logic
+- [`docs/configuration.md`](docs/configuration.md) — all config fields with defaults and examples
+- [`docs/development.md`](docs/development.md) — local development setup and workflow
+
+Read these alongside the code when working on the corresponding areas.
+
+## Architecture
+
+### Custom Resources (5 CRDs)
+
+| CRD | Scope | Purpose |
+| --- | ----- | ------- |
+| **ClusterImageSetMirror / ImageSetMirror** | Cluster / Namespaced | Routes images to mirrored registries and triggers automated image copying |
+| **ClusterReplicatedImageSet / ReplicatedImageSet** | Cluster / Namespaced | Routes images to alternative upstream registries (checks availability, doesn't copy) |
+| **ClusterImageSetAvailability** | Cluster | Monitors image availability across the cluster, tracks per-image status |
+
+Cluster-scoped variants add `spec.namespaceFilter` to limit which namespaces they apply to.
+
+### Entry Point
+
+`cmd/main.go` wires everything into a controller-runtime `Manager`:
+
+- **Webhook server** (`webhook.NewServer`) with TLS — the serving cert is provisioned by cert-manager via `helm/kube-image-keeper/templates/webhook-certificate.yaml` (and `config/certmanager/` for the kustomize layout); `MutatingWebhookConfiguration` carries `cert-manager.io/inject-ca-from` for CA injection
+- **Metrics server** (controller-runtime's `metricsserver`) with optional TLS
+- **Leader election** under ID `e69ca865.enix.io` (off by default; toggled by `--leader-elect`)
+- **Reconcilers** registered against the manager (see Core Packages below)
+
+New work touching reconciler setup, webhook config, manager flags, or TLS plumbing starts here.
+
+### Webhook: Image Rewriting Flow
+
+`internal/webhook/core/v1/pod_webhook.go` is the critical path. On every Pod CREATE:
+
+1. **Global pod filter** — drops pods matching `config.SkipLabels` / `config.SkipAnnotations`; skips mirror pods and pods already annotated with `kuik.enix.io/original-images`
+2. **Per-container filtering** — skips digest-pinned images (`@sha256:...`) and `imagePullPolicy: Never` containers (configurable)
+3. **CR collection** — fetches all applicable CISM/ISM/CRIS/RIS, filtered by `spec.namespaceFilter` and `spec.podFilter`
+4. **Alternative building** — creates a prioritized list including the original image; each entry's position is determined by the two-level priority system (see below)
+5. **Availability checking** — uses `parallel.FirstSuccessful()` with singleflight deduplication and two 1-second TTL caches: `checkCache` (per-image availability boolean) and `alternativeCache` (the resolved alternative for a given original image, which short-circuits re-routing of the same image within the TTL)
+6. **Rewriting** — patches Pod containers; stores original images in `kuik.enix.io/original-images` annotation (JSON) to prevent re-processing
+
+### Two-Level Priority System _(see [`docs/image-routing.md`](docs/image-routing.md))_
+
+**Level 1 — CR priority (`spec.priority`, signed int, default 0):**
+
+- Negative: alternatives placed _before_ the original image (override)
+- Zero: original tried first, alternatives are fallback
+- Positive: alternatives tried after the original with lower priority
+
+**Level 2 — intra-CR priority (`mirrors[].priority` / `upstreams[].priority`, unsigned int, default 0):**
+
+- Lower value = higher priority (same semantics as Linux `nice`)
+- Zero preserves YAML declaration order
+
+Default type order when priorities are equal: Original → CISM → ISM → CRIS → RIS
+
+### Core Packages
+
+- **`internal/filter/`** — three components:
+  - `PodFilter`: label/annotation selector matching (include AND NOT exclude semantics)
+  - `IncludeExcludeFilter`: generic regex-based filter
+  - `PrefixFilter`: wraps any `Filter` to strip a registry prefix before matching
+  - Default-allow semantics (inject `.*` when Include is empty) live in `NamespaceFilterDefinition.Build()` and `ImageFilterDefinition.Build()` in `api/kuik/v1alpha1`
+
+- **`internal/registry/`** — registry interaction via go-containerregistry. `CheckImageAvailability()` returns typed statuses: `Available`, `NotFound`, `Unreachable`, `InvalidAuth`, `QuotaExceeded`. Two additional `ImageAvailabilityStatus` values (`Scheduled`, `UnavailableSecret`) exist but are set by the availability reconciler — not by `CheckImageAvailability()`. `CopyImage()` does the cross-registry transfer that backs mirroring, using `remote.Write` / `remote.WriteIndex` and honouring `config.Mirroring.Platforms`; it's invoked from `commonimagesetmirror.go`. Handles TLS, insecure registries, pull secrets, and rate-limit detection.
+
+- **`internal/parallel/`** — `FirstSuccessful[P,R]()`: runs `f` concurrently on all params, returns the first successful result in original param order along with prior errors.
+
+- **`internal/config/`** — koanf config from `/etc/kube-image-keeper/config.yaml`. Key fields: `SkipLabels`, `SkipAnnotations`, `Routing.ActiveCheck.Timeout`, `Routing.RewriteOnNeverImagePullPolicy`, `Mirroring.Platforms`, `Monitoring.Registries`. Full reference: [`docs/configuration.md`](docs/configuration.md).
+
+- **`internal/controller/kuik/`** — reconcilers:
+  - `ImageSetMirrorReconciler` and `ClusterImageSetMirrorReconciler` — namespaced and cluster-scoped peers, both extending `ImageSetMirrorBaseReconciler` (`commonimagesetmirror.go`) which holds the shared image-copying and stale-mirror-cleanup logic
+  - `ClusterImageSetAvailabilityReconciler` — monitors image availability, updates Prometheus metrics, and is the only place where the `Scheduled` and `UnavailableSecret` statuses are written
+  - `SecretOwnerReconciler[T client.Object]` — generic reconciler that adds a cleanup finalizer to an owner CR and, on deletion, removes every Secret labelled with the owner's UID (`OwnerUIDLabel`). Currently used only to garbage-collect the pull secrets injected into user namespaces for mirroring/replication; `cmd/main.go` instantiates it for `ClusterImageSetMirror` and `ClusterReplicatedImageSet`
+
+- **`internal/info/`** — build-time version metadata (`Version`, `Revision`, `BuildDateTime`, populated via `-ldflags`) and a Prometheus collector that exposes them under the `kube_image_keeper` metrics namespace.
+
+- **`internal/testsetup/`** — side-effect import for test suites that registers a Gomega custom formatter so `*regexp.Regexp` values render as their source string in failure output. Test suites are Ginkgo/Gomega with envtest; suite files follow `suite_test.go` and load CRDs from `config/crd/bases/`. End-to-end tests live under `test/e2e/`.
+
+### Non-Obvious Behaviors
+
+- **Stale mirror cleanup**: when the webhook gets `NotFound` for a mirrored image, it clears `mirroredAt` in the ISM/CISM status, signaling the controller to re-mirror.
+- **Image normalization**: `github.com/distribution/reference.ParseNormalizedNamed()` is used to canonicalize image refs before any comparison.
+- **`make manifests`** syncs generated CRDs into both `config/crd/bases/` and `helm/kube-image-keeper/crds/`; always run it after changing CRD types.
+
+## Change Discipline
+
+Any code change that adds, modifies, or removes behaviour must be accompanied by:
+
+- **Tests** — update or add unit/E2E tests covering the affected behaviour
+- **Documentation** — update `docs/` and, if applicable, Helm chart values docs or README / AGENTS.md sections
+
+## Git Hooks
+
+Lefthook runs `make manifests generate lint-fix` on pre-commit and `make test` on pre-push; conventional commits are enforced. See [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,20 @@ Scopes in commit messages are optional, but when used they must belong to the li
 
 **Proposing a new scope.** Identify which category it belongs to; avoid architectural/layer scopes (`controller`, `webhook`, `crd`) that duplicate feature scopes. Open a pull request updating both `.conform.yaml` and this table.
 
+### Use of AI tools
+
+Concerning AI usage in your contributions, we follow the [Kubernetes AI guidance](https://github.com/kubernetes/community/blob/main/contributors/guide/pull-requests.md#ai-guidance).
+
+Using AI tools to help write your PR is acceptable, but **as the author, you are responsible for understanding every change**. If you used AI tools in preparing your PR, you must disclose this in the description of your PR.
+
+The following rules apply:
+
+- **No AI attribution on commits.** Do not list AI as a co-author, do not co-sign commits with an AI, and do not use trailers like `Assisted-by:` or `Co-developed-by:` referring to an AI. The commit author is the human who submits the work.
+- **Verify before you submit.** Do not leave the first review of AI-generated changes to the reviewers. Run `make test`, exercise the behaviour, confirm the APIs/types you reference actually exist, and read the full diff yourself.
+- **No large AI-generated PRs and no AI-generated commit messages.** Conventional commit subjects and bodies are written by you (see [Pull requests](#pull-requests)).
+- **Be ready to explain your changes.** If, during review, you cannot explain why a change was made, the PR will be closed.
+- **Respond to reviews yourself.** When replying to review comments, do so without relying on AI tools.
+
 ### License
 
 kube-image-keeper is licensed under the [MIT License](./LICENSE). By contributing to this project, you agree to license your contributions under the same license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before contributing to kube-image-keeper, ensure you have all prerequisites inst
 
 ### Git hooks (lefthook)
 
-We use [lefthook](https://github.com/evilmartians/lefthook) to run checks locally (code generation, formatting, linting, commit message linting). After cloning the repository, install lefthook, then register the hooks:
+We use [lefthook](https://github.com/evilmartians/lefthook) to run checks locally (code generation, Go linting, Markdown linting, commit message linting). After cloning the repository, install lefthook, then register the hooks:
 
 ```sh
 # Install lefthook (see https://lefthook.dev/install/ for other methods)
@@ -19,6 +19,8 @@ go install github.com/evilmartians/lefthook@latest
 # Register the git hooks
 lefthook install
 ```
+
+The Markdown lint step runs [`markdownlint-cli2`](https://github.com/DavidAnson/markdownlint-cli2) via `npx` and requires **Node.js ≥ 20**. If Node.js is missing or older, the step is automatically skipped — contributors who don't touch any `.md` files don't need a Node toolchain.
 
 ## Contributing guidelines
 


### PR DESCRIPTION
This add CodeRabbit review for pull requests. Add an `AGENTS.md` file as well as instructions in the `CONTRIBUTING.md` guide about how AI should be used.

There is also a small addition of running markdownlint-cli2 in pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive repository guide covering agent workflows, architecture, testing, and contributor practices
  * Updated contribution guidelines with local hook setup, Node ≥ 20 requirement for markdown linting, and rules for acceptable AI tool use
  * Replaced an empty reference with a link to the main agents guide

* **Chores**
  * Added repository-level automated review configuration for PRs and path-specific review guidance
  * Enabled markdown linting in pre-commit (skips when Node is unavailable or older than 20)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/kube-image-keeper/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->