### PR TITLE
ci: disable CodeRabbit incremental_reviews, arts and finishing touches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,7 @@ language: en-US
 chat:
   # Replies to "@coderabbitai" comments without a leading slash command.
   auto_reply: true
+  art: false
 
 # Style cadre applied to every review.
 tone_instructions: |
@@ -41,6 +42,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    auto_incremental_review: false
+    auto_pause_after_reviewed_commits: 3
     # Skip Dependabot's bot PRs — bumps are mechanical, the diff is
     # just a version number change, and CodeRabbit has nothing useful
     # to say. Same for semantic-release commits that only edit version
@@ -135,3 +138,9 @@ reviews:
         must be reflected here. Flag code changes whose docs were
         not updated in the same PR (see "Change Discipline" in
         AGENTS.md).
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false


### PR DESCRIPTION
CodeRabbit was a bit too noisy IMHO, disabling `auto_incremental_reviews` allows to get a first review and then wait for the author to ask a new review after making changes.

Finishing touches are disabled since they create new commits on the behave of CodeRabbit, which go against our contribution guidelines ("No AI attribution on commits [...] The commit author is the human who submits the work.").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeRabbit review automation configuration by disabling automatic incremental reviews and limiting review frequency after reviewed commits.
  * Disabled art rendering in chat replies and additional finishing touches checks for docstrings and unit tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/kube-image-keeper/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->