### PR TITLE
fix(mirroring): warn instead of fail on missing platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ While both Custom Resources generate alternatives, their behavior differs slight
 
 - The mutating webhook do not support the Pod `Update` call
 - Digest tags are not supported, ex: `@sha256:cb4e4ffc5789fd5ff6a534e3b1460623df61cba00f5ea1c7b40153b5efb81805`
-- Changing `mirroring.platforms` after images have been mirrored does not re-mirror or clean up already-copied manifests (added or removed platforms only apply to subsequent mirror operations)
+- Per-platform mirroring status is not tracked in the (Cluster)ImageSetMirror status. As a result: (1) Kuik cannot report which architectures are actually mirrored for a given image — a mirror is marked successful as long as at least one configured platform is available, and missing platforms are only logged as a warning; and (2) changing `mirroring.platforms` after images have been mirrored does not re-mirror or clean up already-copied manifests (added or removed platforms only apply to subsequent mirror operations)
 
 ## 📦 Installation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ Controls how `ImageSetMirror` and `ClusterImageSetMirror` reconcilers copy image
 
 ### `mirroring.platforms`
 
-List of platform manifests to keep when copying multi-arch images. Single-arch source images are copied as long as they satisfy at least one entry; multi-arch indexes are filtered to only include matching manifests, and the copy fails if any configured platform is missing from the source.
+List of platform manifests to keep when copying multi-arch images. Single-arch source images are copied as long as they satisfy at least one entry; multi-arch indexes are filtered to only include matching manifests. Configured platforms that are not present in the source image are logged as a warning and skipped, so only the intersection of configured and available platforms is mirrored. The copy fails only when the source image has none of the configured platforms.
 
 Defaults to `[{architecture: amd64}]` (single entry, OS and variant unset).
 

--- a/internal/controller/kuik/commonimagesetmirror.go
+++ b/internal/controller/kuik/commonimagesetmirror.go
@@ -107,7 +107,7 @@ func (r *ImageSetMirrorBaseReconciler) mirrorImage(ctx context.Context, namespac
 	defer func() {
 		if err != nil {
 			client := registry.NewClient(nil, nil).WithPullSecrets(destSecrets)
-			_, destErr := client.GetDescriptor(to.Image)
+			_, destErr := client.GetDescriptor(ctx, to.Image)
 			if destErr == nil {
 				logf.FromContext(ctx).V(1).Info("could not mirror image, but the image seems to be already mirrored")
 				err = nil
@@ -118,7 +118,7 @@ func (r *ImageSetMirrorBaseReconciler) mirrorImage(ctx context.Context, namespac
 	}()
 
 	client := registry.NewClient(nil, nil).WithPullSecrets(srcSecrets)
-	srcDesc, err := client.GetDescriptor(from)
+	srcDesc, err := client.GetDescriptor(ctx, from)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func (r *ImageSetMirrorBaseReconciler) cleanupMirror(ctx context.Context, image,
 		return true
 	}
 
-	if err := registry.NewClient(nil, nil).WithPullSecrets([]corev1.Secret{*secret}).DeleteImage(image); err != nil {
+	if err := registry.NewClient(nil, nil).WithPullSecrets([]corev1.Secret{*secret}).DeleteImage(ctx, image); err != nil {
 		log.Error(err, "could not delete image")
 		return false
 	}

--- a/internal/controller/kuik/commonimagesetmirror.go
+++ b/internal/controller/kuik/commonimagesetmirror.go
@@ -124,7 +124,7 @@ func (r *ImageSetMirrorBaseReconciler) mirrorImage(ctx context.Context, namespac
 	}
 
 	// FIXME: if a platform is added or removed, already mirrored images are not updated consequently
-	if err := client.WithTimeout(0).WithPullSecrets(destSecrets).CopyImage(srcDesc, to.Image, r.platforms); err != nil {
+	if err := client.WithTimeout(0).WithPullSecrets(destSecrets).CopyImage(ctx, srcDesc, to.Image, r.platforms); err != nil {
 		return err
 	}
 

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -18,7 +18,7 @@ func CheckImageAvailability(ctx context.Context, reference string, method string
 	_, headers, err := NewClient(nil, nil).
 		WithTimeout(timeout).
 		WithPullSecrets(pullSecrets).
-		ReadDescriptor(method, reference)
+		ReadDescriptor(ctx, method, reference)
 
 	if IsRateLimited(headers) {
 		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded")

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -18,6 +19,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type descriptorReader func(ref name.Reference, options ...remote.Option) (*v1.Descriptor, error)
@@ -131,7 +133,7 @@ func (c *Client) GetDescriptor(imageName string) (*remote.Descriptor, error) {
 	})
 }
 
-func (c *Client) CopyImage(src *remote.Descriptor, dest string, platforms []v1.Platform) error {
+func (c *Client) CopyImage(ctx context.Context, src *remote.Descriptor, dest string, platforms []v1.Platform) error {
 	return c.Execute(dest, func(destRef name.Reference, opts ...remote.Option) (err error) {
 		switch src.MediaType {
 		case types.OCIImageIndex, types.DockerManifestList:
@@ -141,6 +143,9 @@ func (c *Client) CopyImage(src *remote.Descriptor, dest string, platforms []v1.P
 			}
 
 			filteredIndex := mutate.RemoveManifests(index, func(src v1.Descriptor) bool {
+				if src.Platform == nil {
+					return true
+				}
 				return !slices.ContainsFunc(platforms, func(platform v1.Platform) bool {
 					return src.Platform.Satisfies(platform)
 				})
@@ -151,12 +156,15 @@ func (c *Client) CopyImage(src *remote.Descriptor, dest string, platforms []v1.P
 				return err
 			}
 
-			for _, platform := range platforms {
-				if !slices.ContainsFunc(indexManifest.Manifests, func(descriptor v1.Descriptor) bool {
-					return descriptor.Platform.Satisfies(platform)
-				}) {
-					return missingPlatformError(platform)
+			available := make([]v1.Platform, 0, len(indexManifest.Manifests))
+			for _, descriptor := range indexManifest.Manifests {
+				if descriptor.Platform != nil {
+					available = append(available, *descriptor.Platform)
 				}
+			}
+
+			if err := checkPlatforms(ctx, dest, platforms, available); err != nil {
+				return err
 			}
 
 			if err := remote.WriteIndex(destRef, filteredIndex, opts...); err != nil {
@@ -174,10 +182,12 @@ func (c *Client) CopyImage(src *remote.Descriptor, dest string, platforms []v1.P
 			}
 
 			src.Platform = config.Platform()
-			for _, platform := range platforms {
-				if !src.Platform.Satisfies(platform) {
-					return missingPlatformError(platform)
-				}
+			var available []v1.Platform
+			if src.Platform != nil {
+				available = []v1.Platform{*src.Platform}
+			}
+			if err := checkPlatforms(ctx, dest, platforms, available); err != nil {
+				return err
 			}
 
 			if err := remote.Write(destRef, image, opts...); err != nil {
@@ -243,10 +253,53 @@ func ErrIsImageNotFound(err error) bool {
 	return TransportStatusCode(err) == http.StatusNotFound
 }
 
-func missingPlatformError(platform v1.Platform) error {
-	if platform.OS == "" {
-		platform.OS = "_" // String() returns an empty string if OS is empty
-		return fmt.Errorf("missing platform: %s", platform.String()[2:])
+// checkPlatforms keeps the platforms that are available in the source image,
+// warns about the configured ones that are missing, and fails only when none of
+// them are available (nothing to mirror).
+func checkPlatforms(ctx context.Context, image string, configured, available []v1.Platform) error {
+	log := logf.FromContext(ctx)
+	matched, missing := matchPlatforms(configured, available)
+	for _, platform := range missing {
+		log.Info("requested platform not found in source image, skipping it", "image", image, "platform", platformString(platform))
 	}
-	return fmt.Errorf("missing platform: %s", platform.String())
+	if len(matched) == 0 {
+		return noMatchingPlatformError(configured)
+	}
+	return nil
+}
+
+// matchPlatforms splits the configured platforms into those that are available
+// among the source platforms and those that are missing. A configured platform
+// is considered available when at least one source platform satisfies it.
+func matchPlatforms(configured, available []v1.Platform) (matched, missing []v1.Platform) {
+	for _, platform := range configured {
+		if slices.ContainsFunc(available, func(src v1.Platform) bool {
+			return src.Satisfies(platform)
+		}) {
+			matched = append(matched, platform)
+		} else {
+			missing = append(missing, platform)
+		}
+	}
+	return matched, missing
+}
+
+// platformString renders a platform, falling back gracefully when the OS is
+// empty (Platform.String() returns an empty string in that case).
+func platformString(platform v1.Platform) string {
+	if platform.OS == "" {
+		platform.OS = "_"
+		return platform.String()[2:]
+	}
+	return platform.String()
+}
+
+// noMatchingPlatformError is returned when none of the configured platforms are
+// available in the source image, so there is nothing to mirror.
+func noMatchingPlatformError(platforms []v1.Platform) error {
+	strs := make([]string, len(platforms))
+	for i, platform := range platforms {
+		strs[i] = platformString(platform)
+	}
+	return fmt.Errorf("none of the configured platforms are available in the source image: %s", strings.Join(strs, ", "))
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -73,7 +73,7 @@ func (c *Client) WithPullSecrets(pullSecrets []corev1.Secret) *Client {
 }
 
 // Execute execute a callback options including authentication and an optional timeout
-func (c *Client) Execute(imageName string, action func(ref name.Reference, opts ...remote.Option) error) error {
+func (c *Client) Execute(ctx context.Context, imageName string, action func(ref name.Reference, opts ...remote.Option) error) error {
 	keychains, err := GetKeychains(imageName, c.pullSecrets)
 	if err != nil {
 		return err
@@ -84,7 +84,6 @@ func (c *Client) Execute(imageName string, action func(ref name.Reference, opts 
 		return err
 	}
 
-	ctx := context.Background()
 	transportOption := c.newTransportOption(sourceRef)
 
 	if len(keychains) == 0 {
@@ -117,24 +116,24 @@ func (c *Client) Execute(imageName string, action func(ref name.Reference, opts 
 	return errors.Join(errs...)
 }
 
-func (c *Client) ReadDescriptor(httpMethod string, imageName string) (desc *v1.Descriptor, h http.Header, err error) {
-	err = c.Execute(imageName, func(ref name.Reference, opts ...remote.Option) (e error) {
+func (c *Client) ReadDescriptor(ctx context.Context, httpMethod string, imageName string) (desc *v1.Descriptor, h http.Header, err error) {
+	err = c.Execute(ctx, imageName, func(ref name.Reference, opts ...remote.Option) (e error) {
 		desc, e = getReader(httpMethod)(ref, opts...)
 		return e
 	})
 	return desc, c.headerCapture.GetLastHeaders(), err
 }
 
-func (c *Client) GetDescriptor(imageName string) (*remote.Descriptor, error) {
+func (c *Client) GetDescriptor(ctx context.Context, imageName string) (*remote.Descriptor, error) {
 	var desc *remote.Descriptor
-	return desc, c.Execute(imageName, func(ref name.Reference, opts ...remote.Option) (err error) {
+	return desc, c.Execute(ctx, imageName, func(ref name.Reference, opts ...remote.Option) (err error) {
 		desc, err = remote.Get(ref, opts...)
 		return err
 	})
 }
 
 func (c *Client) CopyImage(ctx context.Context, src *remote.Descriptor, dest string, platforms []v1.Platform) error {
-	return c.Execute(dest, func(destRef name.Reference, opts ...remote.Option) (err error) {
+	return c.Execute(ctx, dest, func(destRef name.Reference, opts ...remote.Option) (err error) {
 		switch src.MediaType {
 		case types.OCIImageIndex, types.DockerManifestList:
 			index, err := src.ImageIndex()
@@ -199,8 +198,8 @@ func (c *Client) CopyImage(ctx context.Context, src *remote.Descriptor, dest str
 	})
 }
 
-func (c *Client) DeleteImage(imageName string) error {
-	return c.Execute(imageName, func(ref name.Reference, opts ...remote.Option) (err error) {
+func (c *Client) DeleteImage(ctx context.Context, imageName string) error {
+	return c.Execute(ctx, imageName, func(ref name.Reference, opts ...remote.Option) (err error) {
 		descriptor, err := remote.Head(ref, opts...)
 		if err != nil {
 			if ErrIsImageNotFound(err) {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,12 +1,13 @@
 package registry
 
 import (
+	"context"
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-func TestMissingPlatformError(t *testing.T) {
+func TestPlatformString(t *testing.T) {
 	tests := []struct {
 		name     string
 		platform v1.Platform
@@ -15,34 +16,146 @@ func TestMissingPlatformError(t *testing.T) {
 		{
 			name:     "architecture only",
 			platform: v1.Platform{Architecture: "amd64"},
-			want:     "missing platform: amd64",
+			want:     "amd64",
 		},
 		{
 			name:     "os and architecture",
 			platform: v1.Platform{OS: "linux", Architecture: "amd64"},
-			want:     "missing platform: linux/amd64",
+			want:     "linux/amd64",
 		},
 		{
 			name:     "os, architecture and variant",
 			platform: v1.Platform{OS: "linux", Architecture: "arm64", Variant: "v8"},
-			want:     "missing platform: linux/arm64/v8",
+			want:     "linux/arm64/v8",
 		},
 		{
 			name:     "architecture and variant without os",
 			platform: v1.Platform{Architecture: "arm", Variant: "v7"},
-			want:     "missing platform: arm/v7",
+			want:     "arm/v7",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := missingPlatformError(tt.platform)
-			if err == nil {
-				t.Fatalf("expected error, got nil")
-			}
-			if err.Error() != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, err.Error())
+			if got := platformString(tt.platform); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
 			}
 		})
 	}
+}
+
+func TestMatchPlatforms(t *testing.T) {
+	var (
+		amd64 = v1.Platform{OS: "linux", Architecture: "amd64"}
+		arm64 = v1.Platform{OS: "linux", Architecture: "arm64"}
+	)
+
+	tests := []struct {
+		name        string
+		configured  []v1.Platform
+		available   []v1.Platform
+		wantMatched []v1.Platform
+		wantMissing []v1.Platform
+	}{
+		{
+			name:        "all available",
+			configured:  []v1.Platform{amd64, arm64},
+			available:   []v1.Platform{amd64, arm64},
+			wantMatched: []v1.Platform{amd64, arm64},
+			wantMissing: nil,
+		},
+		{
+			name:        "partial intersection",
+			configured:  []v1.Platform{amd64, arm64},
+			available:   []v1.Platform{arm64},
+			wantMatched: []v1.Platform{arm64},
+			wantMissing: []v1.Platform{amd64},
+		},
+		{
+			name:        "empty intersection",
+			configured:  []v1.Platform{amd64},
+			available:   []v1.Platform{arm64},
+			wantMatched: nil,
+			wantMissing: []v1.Platform{amd64},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, missing := matchPlatforms(tt.configured, tt.available)
+			if !platformsEqual(matched, tt.wantMatched) {
+				t.Fatalf("matched: expected %v, got %v", tt.wantMatched, matched)
+			}
+			if !platformsEqual(missing, tt.wantMissing) {
+				t.Fatalf("missing: expected %v, got %v", tt.wantMissing, missing)
+			}
+		})
+	}
+}
+
+func TestNoMatchingPlatformError(t *testing.T) {
+	err := noMatchingPlatformError([]v1.Platform{
+		{OS: "linux", Architecture: "amd64"},
+		{OS: "linux", Architecture: "arm64"},
+	})
+	want := "none of the configured platforms are available in the source image: linux/amd64, linux/arm64"
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err.Error() != want {
+		t.Fatalf("expected %q, got %q", want, err.Error())
+	}
+}
+
+func TestCheckPlatforms(t *testing.T) {
+	var (
+		amd64 = v1.Platform{OS: "linux", Architecture: "amd64"}
+		arm64 = v1.Platform{OS: "linux", Architecture: "arm64"}
+	)
+
+	// matchPlatforms is covered by TestMatchPlatforms; here we only assert the
+	// decision checkPlatforms owns: error when nothing matches, succeed otherwise.
+	tests := []struct {
+		name       string
+		configured []v1.Platform
+		available  []v1.Platform
+		wantErr    bool
+	}{
+		{
+			name:       "partial intersection succeeds",
+			configured: []v1.Platform{amd64, arm64},
+			available:  []v1.Platform{arm64},
+			wantErr:    false,
+		},
+		{
+			name:       "empty intersection fails",
+			configured: []v1.Platform{amd64},
+			available:  []v1.Platform{arm64},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkPlatforms(context.Background(), "registry/image:tag", tt.configured, tt.available)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func platformsEqual(a, b []v1.Platform) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].String() != b[i].String() {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fail only when no matching platform is available. Closes #594 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified README and configuration docs: per-platform mirroring status isn't tracked; missing configured platforms are logged as warnings and changes to configured platforms after mirroring only affect future operations.

* **Bug Fixes**
  * Mirroring now skips absent configured platforms (warning) and reports failure only when none of the configured platforms are present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/kube-image-keeper/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->