### PR TITLE
feat(routing): add discardAlternative field on (C)RIS upstreams

### DIFF
--- a/api/kuik/v1alpha1/replicatedimageset_types.go
+++ b/api/kuik/v1alpha1/replicatedimageset_types.go
@@ -49,8 +49,13 @@ type ReplicatedUpstream struct {
 	// Positive values are sorted ascending: lower value = higher priority.
 	// +optional
 	Priority uint `json:"priority,omitempty"`
+	// DiscardAlternative excludes this upstream from image routing while keeping it in the configuration.
+	// The upstream still participates in image matching, so other upstreams in the same CR continue to work.
+	// Useful when a registry no longer exists, to avoid waiting for the check timeout.
 	// +optional
+	DiscardAlternative bool `json:"discardAlternative,omitempty"`
 	// ImageFilter defines the rules used to select replicated images.
+	// +optional
 	ImageFilter ImageFilterDefinition `json:"imageFilter"`
 	// CredentialSecret is a reference to the secret used to pull matching images.
 	CredentialSecret *CredentialSecret `json:"credentialSecret,omitempty"`

--- a/config/crd/bases/kuik.enix.io_clusterreplicatedimagesets.yaml
+++ b/config/crd/bases/kuik.enix.io_clusterreplicatedimagesets.yaml
@@ -137,6 +137,12 @@ spec:
                             This value is ignored for namespaced resources and the namespace of the parent object is used instead.
                           type: string
                       type: object
+                    discardAlternative:
+                      description: |-
+                        DiscardAlternative excludes this upstream from image routing while keeping it in the configuration.
+                        The upstream still participates in image matching, so other upstreams in the same CR continue to work.
+                        Useful when a registry no longer exists, to avoid waiting for the check timeout.
+                      type: boolean
                     imageFilter:
                       description: ImageFilter defines the rules used to select replicated
                         images.

--- a/config/crd/bases/kuik.enix.io_replicatedimagesets.yaml
+++ b/config/crd/bases/kuik.enix.io_replicatedimagesets.yaml
@@ -112,6 +112,12 @@ spec:
                             This value is ignored for namespaced resources and the namespace of the parent object is used instead.
                           type: string
                       type: object
+                    discardAlternative:
+                      description: |-
+                        DiscardAlternative excludes this upstream from image routing while keeping it in the configuration.
+                        The upstream still participates in image matching, so other upstreams in the same CR continue to work.
+                        Useful when a registry no longer exists, to avoid waiting for the check timeout.
+                      type: boolean
                     imageFilter:
                       description: ImageFilter defines the rules used to select replicated
                         images.

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -30,6 +30,7 @@ This is particularly useful for multi-homed projects (e.g., Thanos, Prometheus, 
 | `spec.upstreams[].path` | ✅ | Path identifying the image in the registry (e.g. `/thanosio/thanos`). |
 | `spec.upstreams[].priority` | | Controls ordering of this upstream relative to other upstreams with the same parent priority. `0` means no specific ordering (YAML declaration order is preserved). Positive values are sorted ascending: lower value = higher priority. |
 | `spec.upstreams[].imageFilter` | | Rules used to select which images from this upstream are considered replicated. See [Image filtering](./resource-filtering.md#image-filtering-imagefilter). |
+| `spec.upstreams[].discardAlternative` | | When `true`, keeps the upstream in the configuration but excludes it from image routing. The upstream still participates in image matching, so other upstreams in the same CR continue to work. Useful when a registry no longer exists, to avoid waiting for the check timeout. |
 | `spec.upstreams[].credentialSecret` | | Reference to a Secret used to pull matching images from this upstream. |
 | `spec.upstreams[].credentialSecret.name` | | Name of the Secret. |
 | `spec.upstreams[].credentialSecret.namespace` | | Namespace of the Secret. Ignored for namespaced `ReplicatedImageSet` (uses the parent namespace instead). |

--- a/docs/image-routing.md
+++ b/docs/image-routing.md
@@ -159,6 +159,34 @@ For a pod in namespace `my-app` requesting `docker-registry.example.com/my-app/a
 3. `harbor.example.com/global-mirror/my-app/api:v2` (CR priority `-1`)
 4. `docker-registry.example.com/my-app/api:v2` (original image, priority `0`)
 
+## Discarding an upstream without removing it (`discardAlternative`)
+
+Setting `discardAlternative: true` on a `(Cluster)ReplicatedImageSet` upstream keeps the entry in the configuration but excludes it from the list of alternatives the webhook tries. The upstream still participates in image matching (its `imageFilter` can trigger the CR), so other upstreams in the same CR continue to route correctly.
+
+This is useful when a source registry has been migrated or deleted: without this flag the webhook tries the dead registry on every pod admission and waits for the full check timeout before moving on. With `discardAlternative: true` the dead upstream is skipped immediately.
+
+```yaml
+apiVersion: kuik.enix.io/v1alpha1
+kind: ClusterReplicatedImageSet
+metadata:
+  name: bitnami
+spec:
+  upstreams:
+  - registry: docker.io
+    path: /bitnami
+    imageFilter:
+      include:
+      - /bitnami/.*
+    discardAlternative: true # old location, no longer reachable
+  - registry: registry.bitnami.com
+    path: /bitnami
+    imageFilter:
+      include:
+      - /bitnami/.*
+```
+
+In this example, pods referencing `docker.io/bitnami/nginx:latest` will be routed directly to `registry.bitnami.com/bitnami/nginx:latest` without attempting `docker.io` first.
+
 ## Interaction with `imagePullPolicy`
 
 By default, containers with `imagePullPolicy: Always` always pull the original image first; `spec.priority` on `(Cluster)ImageSetMirror` / `(Cluster)ReplicatedImageSet` is not honored for those containers. This preserves the semantic that `Always` should reach the upstream registry even when a higher-priority mirror is declared.

--- a/helm/kube-image-keeper/crds/kuik.enix.io_clusterreplicatedimagesets.yaml
+++ b/helm/kube-image-keeper/crds/kuik.enix.io_clusterreplicatedimagesets.yaml
@@ -136,6 +136,12 @@ spec:
                             This value is ignored for namespaced resources and the namespace of the parent object is used instead.
                           type: string
                       type: object
+                    discardAlternative:
+                      description: |-
+                        DiscardAlternative excludes this upstream from image routing while keeping it in the configuration.
+                        The upstream still participates in image matching, so other upstreams in the same CR continue to work.
+                        Useful when a registry no longer exists, to avoid waiting for the check timeout.
+                      type: boolean
                     imageFilter:
                       description: ImageFilter defines the rules used to select replicated
                         images.

--- a/helm/kube-image-keeper/crds/kuik.enix.io_replicatedimagesets.yaml
+++ b/helm/kube-image-keeper/crds/kuik.enix.io_replicatedimagesets.yaml
@@ -111,6 +111,12 @@ spec:
                             This value is ignored for namespaced resources and the namespace of the parent object is used instead.
                           type: string
                       type: object
+                    discardAlternative:
+                      description: |-
+                        DiscardAlternative excludes this upstream from image routing while keeping it in the configuration.
+                        The upstream still participates in image matching, so other upstreams in the same CR continue to work.
+                        Useful when a registry no longer exists, to avoid waiting for the check timeout.
+                      type: boolean
                     imageFilter:
                       description: ImageFilter defines the rules used to select replicated
                         images.

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -463,18 +463,7 @@ func (d *PodCustomDefaulter) buildAlternativesList(ctx context.Context, imageSet
 	normalizedImage := container.NormalizedImage
 	alternatives := make([]prioritizedAlternative, 0, 1)
 
-	// Collect original image. By default, containers with imagePullPolicy: Always
-	// pin the original first regardless of CR priorities; mirrors/upstreams are
-	// still appended as fallback. Set HonorPrioritiesOnAlwaysImagePullPolicy to
-	// opt into priority sorting for those containers.
-	original := prioritizedAlternative{
-		reference: normalizedImage,
-		typeOrder: crTypeOrderOriginal,
-	}
-	if container.ImagePullPolicy == corev1.PullAlways && !d.Config.Routing.HonorPrioritiesOnAlwaysImagePullPolicy {
-		original.crPriority = math.MinInt
-	}
-	alternatives = append(alternatives, original)
+	discardOriginal := false
 
 	// Collect from ReplicatedImageSets
 	for risIdx := range replicatedImageSets {
@@ -488,6 +477,11 @@ func (d *PodCustomDefaulter) buildAlternativesList(ctx context.Context, imageSet
 		}
 
 		match := &ris.Spec.Upstreams[index]
+		if match.DiscardAlternative {
+			// A matching upstream with DiscardAlternative enabled prevents the original registry from
+			// being used as a fallback. We set discardOriginal to true here to suppress it later.
+			discardOriginal = true
+		}
 		prefix := path.Join(match.Registry, match.Path)
 		suffix := strings.TrimPrefix(normalizedImage, prefix)
 
@@ -497,6 +491,9 @@ func (d *PodCustomDefaulter) buildAlternativesList(ctx context.Context, imageSet
 		}
 
 		for declarationIdx, upstream := range ris.Spec.Upstreams {
+			if upstream.DiscardAlternative {
+				continue
+			}
 			alternatives = append(alternatives, prioritizedAlternative{
 				reference:        path.Join(upstream.Registry, upstream.Path) + suffix,
 				credentialSecret: upstream.CredentialSecret,
@@ -507,6 +504,21 @@ func (d *PodCustomDefaulter) buildAlternativesList(ctx context.Context, imageSet
 				declarationOrder: declarationIdx,
 			})
 		}
+	}
+
+	if !discardOriginal {
+		// By default, containers with imagePullPolicy: Always pin the original first
+		// regardless of CR priorities; mirrors/upstreams are still appended as
+		// fallback. Set HonorPrioritiesOnAlwaysImagePullPolicy to opt into priority
+		// sorting for those containers.
+		original := prioritizedAlternative{
+			reference: normalizedImage,
+			typeOrder: crTypeOrderOriginal,
+		}
+		if container.ImagePullPolicy == corev1.PullAlways && !d.Config.Routing.HonorPrioritiesOnAlwaysImagePullPolicy {
+			original.crPriority = math.MinInt
+		}
+		alternatives = append(alternatives, original)
 	}
 
 	// Collect from ImageSetMirrors

--- a/internal/webhook/core/v1/pod_webhook_test.go
+++ b/internal/webhook/core/v1/pod_webhook_test.go
@@ -349,6 +349,24 @@ var _ = Describe("buildAlternativesList", func() {
 		}
 	}
 
+	makeRIS := func(upstreams ...kuikv1alpha1.ReplicatedUpstream) kuikv1alpha1.ReplicatedImageSet {
+		return kuikv1alpha1.ReplicatedImageSet{
+			Spec: kuikv1alpha1.ReplicatedImageSetSpec{
+				Upstreams: upstreams,
+			},
+		}
+	}
+
+	makeUpstream := func(registry string, discard bool) kuikv1alpha1.ReplicatedUpstream {
+		return kuikv1alpha1.ReplicatedUpstream{
+			ImageReference: kuikv1alpha1.ImageReference{Registry: registry},
+			ImageFilter: kuikv1alpha1.ImageFilterDefinition{
+				Include: []string{".*"},
+			},
+			DiscardAlternative: discard,
+		}
+	}
+
 	cismWithMirror := func(priority int, registry, mirrorPath string) kuikv1alpha1.ImageSetMirror {
 		return kuikv1alpha1.ImageSetMirror{
 			ObjectMeta: metav1.ObjectMeta{Name: "global"},
@@ -409,6 +427,68 @@ var _ = Describe("buildAlternativesList", func() {
 			Expect(references(c)).To(Equal([]string{
 				"docker.io/library/nginx:1.29",
 				"harbor.example.com/mirror/library/nginx:1.29",
+			}))
+		})
+	})
+
+	Context("with discardAlternative", func() {
+		It("excludes a discarded upstream from the alternatives list", func() {
+			c := makeContainer("docker.io/library/nginx:1.29", corev1.PullIfNotPresent)
+			err := d.buildAlternativesList(
+				ctx,
+				nil,
+				[]kuikv1alpha1.ReplicatedImageSet{
+					makeRIS(makeUpstream("docker.io", true)),
+				},
+				c,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(references(c)).To(Equal([]string{}))
+		})
+
+		ris := []kuikv1alpha1.ReplicatedImageSet{
+			makeRIS(
+				makeUpstream("docker.io", true),
+				makeUpstream("mirror.example.com", false),
+			),
+		}
+
+		It("excludes a discarded upstream while keeping the active one", func() {
+			c := makeContainer("mirror.example.com/library/nginx:1.29", corev1.PullIfNotPresent)
+			err := d.buildAlternativesList(ctx, nil, ris, c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(references(c)).To(Equal([]string{
+				"mirror.example.com/library/nginx:1.29",
+			}))
+		})
+
+		It("matches a upstream that have been discarded without routing it", func() {
+			c := makeContainer("docker.io/library/nginx:1.29", corev1.PullIfNotPresent)
+			err := d.buildAlternativesList(ctx, nil, ris, c)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(references(c)).To(Equal([]string{
+				"mirror.example.com/library/nginx:1.29",
+			}))
+		})
+
+		It("keep the original image when the discarded upstream is not the one that it matches", func() {
+			c := makeContainer("docker.io/library/nginx:1.29", corev1.PullIfNotPresent)
+			err := d.buildAlternativesList(
+				ctx,
+				nil,
+				[]kuikv1alpha1.ReplicatedImageSet{
+					makeRIS(
+						makeUpstream("mirror1.example.com", true),
+						makeUpstream("mirror2.example.com", false),
+						makeUpstream("docker.io", false),
+					),
+				},
+				c,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(references(c)).To(Equal([]string{
+				"docker.io/library/nginx:1.29",
+				"mirror2.example.com/library/nginx:1.29",
 			}))
 		})
 	})


### PR DESCRIPTION
Closes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `discardAlternative` option for upstreams to keep them configured and matched but exclude them from image routing and availability checks.

* **Documentation**
  * Documented `discardAlternative` behavior in CRD and image-routing docs.

* **Tests**
  * Added tests covering `discardAlternative` behavior and alternative-image list generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enix/kube-image-keeper/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->