### PR TITLE
fix: mirror private upstreams using (Cluster)ReplicatedImageSet source credentials (#606)

### DIFF
--- a/internal/controller/kuik/commonimagesetmirror.go
+++ b/internal/controller/kuik/commonimagesetmirror.go
@@ -93,6 +93,83 @@ func (r *ImageSetMirrorBaseReconciler) getPullSecretsFromPods(ctx context.Contex
 	return secrets, nil
 }
 
+// matchUpstreamCredentialSecret returns the CredentialSecret of the first
+// ReplicatedUpstream whose ImageFilter (compiled with its registry) matches
+// image, or nil if none matches. This mirrors how the pod webhook resolves
+// the upstream source credential in buildAlternativesList, so the mirror
+// controller authenticates to a private upstream exactly like the webhook
+// does when it checks availability.
+func matchUpstreamCredentialSecret(upstreams []kuikv1alpha1.ReplicatedUpstream, image string) *kuikv1alpha1.CredentialSecret {
+	for i := range upstreams {
+		upstream := &upstreams[i]
+		if upstream.CredentialSecret == nil {
+			continue
+		}
+		if upstream.ImageFilter.MustBuildWithRegistry(upstream.Registry).Match(image) {
+			return upstream.CredentialSecret
+		}
+	}
+	return nil
+}
+
+// getSourceSecretFromReplicatedImageSets resolves the SOURCE (upstream)
+// credential for the image being mirrored from the CredentialSecret declared
+// on a matching (Cluster)ReplicatedImageSet upstream.
+//
+// This closes the gap that breaks mirroring of private upstreams (issue #606):
+// getPullSecretsFromPods can only contribute credentials while a pod still
+// references the original image, but the webhook rewrites consumers to pull
+// from the mirror at admission time, so in steady state no pod carries the
+// original reference and srcSecrets ends up empty. The upstream credential the
+// operator already declared on the (Cluster)ReplicatedImageSet — described as
+// "the secret used to pull matching images" — is the natural source of truth.
+//
+// ClusterReplicatedImageSet (cluster-scoped) is always consulted. For a
+// namespaced ImageSetMirror, ReplicatedImageSets in its namespace are also
+// considered, with the secret resolved in that namespace.
+func (r *ImageSetMirrorBaseReconciler) getSourceSecretFromReplicatedImageSets(ctx context.Context, image, namespace string) (*corev1.Secret, error) {
+	var credentialSecret *kuikv1alpha1.CredentialSecret
+
+	var crisList kuikv1alpha1.ClusterReplicatedImageSetList
+	if err := r.List(ctx, &crisList); err != nil {
+		return nil, err
+	}
+	for i := range crisList.Items {
+		if cs := matchUpstreamCredentialSecret(crisList.Items[i].Spec.Upstreams, image); cs != nil {
+			credentialSecret = cs
+			break
+		}
+	}
+
+	if credentialSecret == nil && namespace != "" {
+		var risList kuikv1alpha1.ReplicatedImageSetList
+		if err := r.List(ctx, &risList, client.InNamespace(namespace)); err != nil {
+			return nil, err
+		}
+		for i := range risList.Items {
+			ris := &risList.Items[i]
+			if cs := matchUpstreamCredentialSecret(ris.Spec.Upstreams, image); cs != nil {
+				// CredentialSecret.Namespace is ignored for namespaced
+				// resources; the secret lives in the RIS' own namespace.
+				qualified := *cs
+				qualified.Namespace = ris.Namespace
+				credentialSecret = &qualified
+				break
+			}
+		}
+	}
+
+	if credentialSecret == nil {
+		return nil, nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.getPullSecret(ctx, credentialSecret.Namespace, credentialSecret.Name, secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
 func (r *ImageSetMirrorBaseReconciler) getImageSecretFromMirrors(ctx context.Context, image, namespace string, mirrors kuikv1alpha1.Mirrors) (*corev1.Secret, error) {
 	destCredentialSecret := mirrors.GetCredentialSecretForImage(image)
 
@@ -117,6 +194,22 @@ func (r *ImageSetMirrorBaseReconciler) mirrorImage(ctx context.Context, namespac
 	srcSecrets, err := r.getPullSecretsFromPods(ctx, podsByMatchingImages, from)
 	if err != nil {
 		return err
+	}
+
+	// When no consuming pod contributes credentials — the steady-state case
+	// once the webhook has rewritten workloads to pull from the mirror — fall
+	// back to the source CredentialSecret declared on a matching
+	// (Cluster)ReplicatedImageSet upstream. Without this, private upstreams
+	// (Docker Hub, private quay.io, ...) fail to mirror with 401 UNAUTHORIZED
+	// (issue #606).
+	if len(srcSecrets) == 0 {
+		secret, err := r.getSourceSecretFromReplicatedImageSets(ctx, from, namespace)
+		if err != nil {
+			return err
+		}
+		if secret != nil {
+			srcSecrets = []corev1.Secret{*secret}
+		}
 	}
 
 	destSecrets := make([]corev1.Secret, 1)

--- a/internal/controller/kuik/mirror_source_credential_test.go
+++ b/internal/controller/kuik/mirror_source_credential_test.go
@@ -1,0 +1,153 @@
+package kuik
+
+import (
+	"context"
+
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// These tests cover the source-credential fallback that fixes issue #606:
+// once the webhook has rewritten consumers to pull from the mirror, no pod
+// carries the original image, so the mirror controller must resolve the
+// upstream credential from a matching (Cluster)ReplicatedImageSet upstream.
+var _ = Describe("Mirror source credential resolution (issue #606)", func() {
+	ctx := context.Background()
+
+	const (
+		dockerImage = "docker.io/library/nginx:1.25"
+		quayImage   = "quay.io/prometheus/node-exporter:v1.8.0"
+	)
+
+	newReconciler := func() *ImageSetMirrorBaseReconciler {
+		return &ImageSetMirrorBaseReconciler{
+			Client: k8sClient,
+			Scheme: k8sClient.Scheme(),
+		}
+	}
+
+	makeSecret := func(name, namespace string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Type:       corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{"https://index.docker.io/v1/":{"auth":"dXNlcjpwYXNz"}}}`),
+			},
+		}
+	}
+
+	dockerUpstream := func(secretName, secretNamespace string) kuikv1alpha1.ReplicatedUpstream {
+		up := kuikv1alpha1.ReplicatedUpstream{
+			ImageReference: kuikv1alpha1.ImageReference{Registry: "docker.io"},
+			ImageFilter:    kuikv1alpha1.ImageFilterDefinition{Include: []string{".*"}},
+		}
+		if secretName != "" {
+			up.CredentialSecret = &kuikv1alpha1.CredentialSecret{Name: secretName, Namespace: secretNamespace}
+		}
+		return up
+	}
+
+	makeCRIS := func(name string, upstreams ...kuikv1alpha1.ReplicatedUpstream) *kuikv1alpha1.ClusterReplicatedImageSet {
+		return &kuikv1alpha1.ClusterReplicatedImageSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: kuikv1alpha1.ClusterReplicatedImageSetSpec{
+				ReplicatedImageSetSpec: kuikv1alpha1.ReplicatedImageSetSpec{Upstreams: upstreams},
+			},
+		}
+	}
+
+	makeRIS := func(name, namespace string, upstreams ...kuikv1alpha1.ReplicatedUpstream) *kuikv1alpha1.ReplicatedImageSet {
+		return &kuikv1alpha1.ReplicatedImageSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       kuikv1alpha1.ReplicatedImageSetSpec{Upstreams: upstreams},
+		}
+	}
+
+	create := func(obj client.Object) {
+		Expect(k8sClient.Create(ctx, obj)).To(Succeed())
+		DeferCleanup(func() { Expect(k8sClient.Delete(ctx, obj)).To(Succeed()) })
+	}
+
+	Context("ClusterReplicatedImageSet (cluster-scoped source)", func() {
+		It("resolves the source secret from a matching upstream", func() {
+			create(makeSecret("cris-docker-creds", "default"))
+			create(makeCRIS("cris-docker", dockerUpstream("cris-docker-creds", "default")))
+
+			got, err := newReconciler().getSourceSecretFromReplicatedImageSets(ctx, dockerImage, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(got.Name).To(Equal("cris-docker-creds"))
+			Expect(got.Namespace).To(Equal("default"))
+		})
+
+		It("returns nil when no upstream matches the image", func() {
+			create(makeSecret("cris-docker-creds2", "default"))
+			create(makeCRIS("cris-docker-only", dockerUpstream("cris-docker-creds2", "default")))
+
+			got, err := newReconciler().getSourceSecretFromReplicatedImageSets(ctx, quayImage, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+
+		It("returns nil when the matching upstream declares no CredentialSecret", func() {
+			create(makeCRIS("cris-no-cred", dockerUpstream("", "")))
+
+			got, err := newReconciler().getSourceSecretFromReplicatedImageSets(ctx, dockerImage, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+	})
+
+	Context("ReplicatedImageSet (namespaced source)", func() {
+		It("resolves the secret in the RIS namespace for a namespaced ImageSetMirror", func() {
+			create(makeSecret("ris-docker-creds", "default"))
+			// CredentialSecret.Namespace ("ignored") must be overridden with
+			// the RIS' own namespace for namespaced resources.
+			create(makeRIS("ris-docker", "default", dockerUpstream("ris-docker-creds", "ignored")))
+
+			got, err := newReconciler().getSourceSecretFromReplicatedImageSets(ctx, dockerImage, "default")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).NotTo(BeNil())
+			Expect(got.Name).To(Equal("ris-docker-creds"))
+			Expect(got.Namespace).To(Equal("default"))
+		})
+
+		It("does not consult namespaced ReplicatedImageSets for a cluster-scoped mirror (namespace empty)", func() {
+			create(makeSecret("ris-isolated-creds", "default"))
+			create(makeRIS("ris-isolated", "default", dockerUpstream("ris-isolated-creds", "default")))
+
+			got, err := newReconciler().getSourceSecretFromReplicatedImageSets(ctx, dockerImage, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(BeNil())
+		})
+	})
+
+	Context("matchUpstreamCredentialSecret", func() {
+		upstreams := []kuikv1alpha1.ReplicatedUpstream{
+			{
+				ImageReference:   kuikv1alpha1.ImageReference{Registry: "quay.io"},
+				ImageFilter:      kuikv1alpha1.ImageFilterDefinition{Include: []string{".*"}},
+				CredentialSecret: &kuikv1alpha1.CredentialSecret{Name: "quay"},
+			},
+			{
+				ImageReference:   kuikv1alpha1.ImageReference{Registry: "docker.io"},
+				ImageFilter:      kuikv1alpha1.ImageFilterDefinition{Include: []string{".*"}},
+				CredentialSecret: &kuikv1alpha1.CredentialSecret{Name: "docker"},
+			},
+		}
+
+		It("returns the credential of the first matching upstream", func() {
+			cs := matchUpstreamCredentialSecret(upstreams, dockerImage)
+			Expect(cs).NotTo(BeNil())
+			Expect(cs.Name).To(Equal("docker"))
+		})
+
+		It("returns nil when nothing matches", func() {
+			Expect(matchUpstreamCredentialSecret(upstreams, "ghcr.io/foo/bar:latest")).To(BeNil())
+		})
+	})
+})

--- a/internal/registry/keychain.go
+++ b/internal/registry/keychain.go
@@ -3,9 +3,9 @@ package registry
 import (
 	"fmt"
 
-	"github.com/distribution/reference"
 	"github.com/enix/kube-image-keeper/internal/registry/credentialprovider/secrets"
 	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -32,10 +32,19 @@ func GetKeychains(repositoryName string, pullSecrets []corev1.Secret) ([]authn.K
 func getKeychainsFromSecrets(repositoryName string, pullSecrets []corev1.Secret) ([]authn.Keychain, error) {
 	keychains := []authn.Keychain{}
 
-	named, err := reference.ParseNormalizedNamed(repositoryName)
+	// Use go-containerregistry/pkg/name to canonicalize the repository name
+	// so that Resolve()'s strict equality below matches what
+	// remote.{Get,Write,Head} hands us as target.String(). The previous
+	// implementation used distribution/reference, which normalizes Docker
+	// Hub as "docker.io/..." while go-containerregistry normalizes it as
+	// "index.docker.io/..." — the mismatch caused Resolve() to always
+	// return Anonymous for Docker Hub images, regardless of valid creds in
+	// the pullSecrets keyring.
+	ref, err := name.ParseReference(repositoryName)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse image name: %v", err)
 	}
+	canonicalName := ref.Context().Name()
 
 	keyring, err := secrets.MakeDockerKeyring(pullSecrets)
 	if err != nil {
@@ -46,10 +55,10 @@ func getKeychainsFromSecrets(repositoryName string, pullSecrets []corev1.Secret)
 		return keychains, nil
 	}
 
-	creds, _ := keyring.Lookup(named.Name())
+	creds, _ := keyring.Lookup(canonicalName)
 	for _, cred := range creds {
 		keychains = append(keychains, &authConfigKeychain{
-			repositoryName: named.Name(),
+			repositoryName: canonicalName,
 			AuthConfig: authn.AuthConfig{
 				Username:      cred.Username,
 				Password:      cred.Password,

--- a/internal/registry/keychain_test.go
+++ b/internal/registry/keychain_test.go
@@ -1,0 +1,138 @@
+package registry
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// dockerCfgSecret builds a kubernetes.io/dockerconfigjson Secret for one
+// registry hostname.
+func dockerCfgSecret(registry, username, password string) corev1.Secret {
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	cfg := map[string]any{
+		"auths": map[string]any{
+			registry: map[string]any{
+				"username": username,
+				"password": password,
+				"auth":     auth,
+			},
+		},
+	}
+	raw, _ := json.Marshal(cfg)
+	return corev1.Secret{
+		Type: corev1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{corev1.DockerConfigJsonKey: raw},
+	}
+}
+
+// resolveOne is a small helper: pull the only matching keychain for an
+// image and ask it to Resolve the image's repository, returning the
+// resulting Authenticator (Anonymous on miss).
+func resolveOne(t *testing.T, image string, secret corev1.Secret) authn.Authenticator {
+	t.Helper()
+	keychains, err := GetKeychains(image, []corev1.Secret{secret})
+	if err != nil {
+		t.Fatalf("GetKeychains: %v", err)
+	}
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		t.Fatalf("ParseReference: %v", err)
+	}
+	if len(keychains) == 0 {
+		return authn.Anonymous
+	}
+	auth, err := keychains[0].Resolve(ref.Context())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	return auth
+}
+
+func mustAuthConfig(t *testing.T, a authn.Authenticator) authn.AuthConfig {
+	t.Helper()
+	cfg, err := a.Authorization()
+	if err != nil {
+		t.Fatalf("Authorization: %v", err)
+	}
+	return *cfg
+}
+
+// TestKeychainResolve_DockerHub regression-guards the
+// distribution/reference vs go-containerregistry normalization mismatch.
+// reference.ParseNormalizedNamed(...).Name() returns "docker.io/...",
+// while name.ParseReference(...).Context().Name() returns
+// "index.docker.io/...". With the old code, authConfigKeychain.Resolve()
+// always returned Anonymous for Docker Hub images even with valid
+// credentials.
+//
+// Note: a secret built with --docker-server=docker.io (bare host, no
+// `index.` prefix) is NOT covered. That's an upstream kubelet keyring
+// quirk — Lookup() Adds the secret under its own host key, URLsMatchStr
+// won't match it against index.docker.io/..., and the default-registry
+// fallback only looks up the literal key "index.docker.io". This is
+// independent of the keychain bug we're fixing; the operator must use
+// `index.docker.io` or `https://index.docker.io/v1/` in the Secret.
+func TestKeychainResolve_DockerHub(t *testing.T) {
+	cases := []struct {
+		name       string
+		image      string
+		secretHost string
+	}{
+		{"image-docker.io,secret-index.docker.io", "docker.io/actian/foo:1", "index.docker.io"},
+		{"image-docker.io,secret-https://index.docker.io/v1/", "docker.io/actian/foo:1", "https://index.docker.io/v1/"},
+		{"image-index.docker.io,secret-index.docker.io", "index.docker.io/actian/foo:1", "index.docker.io"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			secret := dockerCfgSecret(tc.secretHost, "u", "p")
+			auth := resolveOne(t, tc.image, secret)
+			if auth == authn.Anonymous {
+				t.Fatalf("expected creds, got Anonymous (%s / %s)", tc.image, tc.secretHost)
+			}
+			cfg := mustAuthConfig(t, auth)
+			if cfg.Username != "u" || cfg.Password != "p" {
+				t.Fatalf("wrong creds: %+v", cfg)
+			}
+		})
+	}
+}
+
+// TestKeychainResolve_OtherRegistries makes sure the new canonicalization
+// (via go-containerregistry/pkg/name) leaves non-docker.io registries
+// alone.
+func TestKeychainResolve_OtherRegistries(t *testing.T) {
+	cases := []struct {
+		image      string
+		secretHost string
+	}{
+		{"quay.io/enix/manager:1", "quay.io"},
+		{"123456789012.dkr.ecr.us-east-1.amazonaws.com/foo:1", "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+		{"us-docker.pkg.dev/proj/repo/img:1", "us-docker.pkg.dev"},
+		{"ghcr.io/owner/img:1", "ghcr.io"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%s+%s", tc.image, tc.secretHost), func(t *testing.T) {
+			secret := dockerCfgSecret(tc.secretHost, "u", "p")
+			auth := resolveOne(t, tc.image, secret)
+			if auth == authn.Anonymous {
+				t.Fatalf("expected creds, got Anonymous (%s / %s)", tc.image, tc.secretHost)
+			}
+		})
+	}
+}
+
+// TestKeychainResolve_DifferentRegistry makes sure a secret for one
+// registry does NOT resolve credentials for an unrelated registry.
+func TestKeychainResolve_DifferentRegistry(t *testing.T) {
+	secret := dockerCfgSecret("quay.io", "u", "p")
+	auth := resolveOne(t, "ghcr.io/owner/img:1", secret)
+	if auth != authn.Anonymous {
+		t.Fatalf("expected Anonymous, got %+v", auth)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #606 — mirroring images from a **private upstream** (Docker Hub in the
report, also private quay.io, etc.) fails with `401 UNAUTHORIZED /
authentication required`, even though credentials are declared and the
workload pods pull the same images fine.

Two independent root causes:

### 1. Keychain repo-name mismatch (always anonymous for Docker Hub)

`getKeychainsFromSecrets` parsed the repository name with
`distribution/reference`, which normalizes Docker Hub as `docker.io/...`. The
credential `Resolve()` path compares against the target string produced by
`go-containerregistry`'s `remote.{Get,Write,Head}`, which normalizes Docker
Hub as `index.docker.io/...`. The strict-equality check never matched, so
`Resolve()` returned `Anonymous` for Docker Hub regardless of valid creds in
the keyring.

Fix: canonicalize the repository name with `go-containerregistry/pkg/name`
(`ref.Context().Name()`) so it matches the `Resolve()` target.

### 2. Source credentials declared on (Cluster)ReplicatedImageSet are never used

The mirror controller derived source credentials **only** from pods that still
reference the original image (`getPullSecretsFromPods`). But the webhook
rewrites consumers to pull from the mirror **at admission time**, so in steady
state no pod carries the original reference, `srcSecrets` is empty, and the
source pull is anonymous.

Meanwhile `ReplicatedUpstream.CredentialSecret` — documented as *"the secret
used to pull matching images"* and already read by the webhook for its
availability check — was never consulted by the mirror controller. This is
exactly where the #606 reporter put their Docker Hub credentials (on a
`ClusterReplicatedImageSet`).

Fix: when no pod contributes credentials, resolve the source secret from the
`CredentialSecret` of the matching `(Cluster)ReplicatedImageSet` upstream,
reusing the same filter-match logic the webhook uses in
`buildAlternativesList`.

This **preserves the d26a099 / #567 decision** — mirror matching stays driven
by the current (rewritten) image. It only adds a credential *source*, not a new
matching path. `ClusterReplicatedImageSet` (cluster-scoped) is always
consulted; `ReplicatedImageSet`s in the `ImageSetMirror`'s namespace are also
consulted for namespaced mirrors. Existing controller RBAC already grants
`get;list;watch` on both resources, so no RBAC changes are required.

## Changes

- `internal/registry/keychain.go` — canonicalize repo name via `pkg/name`
- `internal/controller/kuik/commonimagesetmirror.go` —
  `getSourceSecretFromReplicatedImageSets` / `matchUpstreamCredentialSecret`,
  used as a source-credential fallback in `mirrorImage`

## Testing

- `internal/registry/keychain_test.go` — Docker Hub canonicalization / Resolve match
- `internal/controller/kuik/mirror_source_credential_test.go` — CRIS/RIS source-credential resolution, no-match and no-credential cases, namespace scoping
- Full suite (`go test ./... excluding e2e`) passes locally against envtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
