### PR TITLE
docs: fix broken link to protect-images-from-garbage-collection use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ While both Custom Resources generate alternatives, their behavior differs slight
 - You have plenty of images (outdated, prior versions, development version) but only a small fraction is being used in reality
 - You would like to push only a subset of useful images to your production registry
 
-&emsp;[Implementation guide](https://kuik.enix.io/use-cases/protect-images-from-garbage-collect/)
+&emsp;[Implementation guide](https://kuik.enix.io/use-cases/protect-images-from-garbage-collection/)
 
 ### ✅ Automatically route images to a proxy cache registry
 


### PR DESCRIPTION
The link in the README was missing the `ion` suffix, pointing to `garbage-collect` instead of `garbage-collection`, causing a 404.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed incorrect URL path reference in the "Protect images from garbage collection" section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->