### PR TITLE
fix(availability): add opt-in digest-path check to detect stale tag caches

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this envelope covers both requests. |
-| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. Doubles the number of requests per admission. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this single envelope covers both the tag and digest requests sequentially; increase to at least `2s`–`3s` to give each request a fair share of the budget. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true` and the reference is a tag, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. References already by digest are not rechecked. Doubles the number of requests per tag admission. |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -102,16 +102,31 @@ Controls the mutating webhook that rewrites Pod container images.
 
 Durations use Go's `time.ParseDuration` syntax (`"500ms"`, `"30s"`, `"2h"`, ...).
 
-### Example
+### Examples
 
-Lower the active-check timeout, keep `Always` containers in the standard
-priority sort:
+Lower the active-check timeout and keep `Always` containers in the standard priority sort:
 
 ```yaml
 routing:
   activeCheck:
     timeout: 500ms
   honorPrioritiesOnAlwaysImagePullPolicy: true
+```
+
+Enable digest-path verification and adjust rate limits to account for doubled requests:
+
+```yaml
+routing:
+  activeCheck:
+    resolveDigest: true
+    timeout: 3s  # increase from the 1s default — resolveDigest makes two sequential requests
+
+monitoring:
+  registries:
+    items:
+      docker.io:
+        interval: 1h
+        maxPerInterval: 3  # halved from 6 — resolveDigest doubles per-image request count
 ```
 
 ## `mirroring`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,7 +93,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this envelope covers both requests. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. Doubles the number of requests per admission. |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -165,8 +166,9 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled each check makes two requests; halve this value for rate-constrained registries to avoid quota exhaustion. |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
+| `resolveDigest` | bool | unset (disabled) | When `true`, a second request is made by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies. Doubles request quota. Set to `false` in an `items` override to disable for a specific registry that inherits a `true` default. |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |
 
 ### Default for `monitoring.registries.items`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this single envelope covers both the tag and digest requests sequentially; increase to at least `2s`–`3s` to give each request a fair share of the budget. |
-| `routing.activeCheck.resolveDigest` | bool | `false` | When `true` and the reference is a tag, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. References already by digest are not rechecked. Doubles the number of requests per tag admission. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled, this budget covers both requests. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, tag references are checked a second time by manifest digest, catching registries that serve a tag whose manifest is gone. References already pinned to a digest are not rechecked. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -102,7 +102,7 @@ Controls the mutating webhook that rewrites Pod container images.
 
 Durations use Go's `time.ParseDuration` syntax (`"500ms"`, `"30s"`, `"2h"`, ...).
 
-### Examples
+### Example
 
 Lower the active-check timeout and keep `Always` containers in the standard priority sort:
 
@@ -111,22 +111,6 @@ routing:
   activeCheck:
     timeout: 500ms
   honorPrioritiesOnAlwaysImagePullPolicy: true
-```
-
-Enable digest-path verification and adjust rate limits to account for doubled requests:
-
-```yaml
-routing:
-  activeCheck:
-    resolveDigest: true
-    timeout: 3s  # increase from the 1s default — resolveDigest makes two sequential requests
-
-monitoring:
-  registries:
-    items:
-      docker.io:
-        interval: 1h
-        maxPerInterval: 3  # halved from 6 — resolveDigest doubles per-image request count
 ```
 
 ## `mirroring`
@@ -181,9 +165,9 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled each check makes two requests; halve this value for rate-constrained registries to avoid quota exhaustion. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each check makes two requests. |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
-| `resolveDigest` | bool | unset (disabled) | When `true`, a second request is made by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies. Doubles request quota. Set to `false` in an `items` override to disable for a specific registry that inherits a `true` default. |
+| `resolveDigest` | bool | unset (disabled) | Same digest check as `routing.activeCheck.resolveDigest`, applied to monitoring probes. An `items` entry leaving it unset inherits the `default` value; setting it to `false` opts that registry out. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |
 
 ### Default for `monitoring.registries.items`

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,5 +1,41 @@
 # Troubleshooting
 
+## Stale tag caches on pull-through proxies
+
+**Symptom:** kuik reports an image as available (and keeps routing pods to it), but pods pulling it fail with `manifest unknown` or `not found` on every node that does not already have the image in its local store.
+
+By default, the availability check does what a plain `docker pull` of a tag starts with: one `HEAD` (or `GET`) on the tag. Container runtimes do more, they resolve the tag to a manifest digest, then fetch the manifest *by that digest*. Some registries answer the two requests inconsistently:
+
+- a pull-through proxy whose upstream image was deleted or garbage-collected keeps serving the cached tag while the manifest behind it is gone;
+- a scanner-gated registry (Artifactory with Xray, for instance) can block a specific manifest by digest while the tag lookup still succeeds.
+
+In both cases the tag request returns `200`, kuik marks the image `Available`, and the pull fails anyway. Setting `resolveDigest: true` makes kuik follow the same two-step path as the runtime. A `404` on the digest request is reported as `NotFound` with a `tag/digest inconsistency` message, which triggers the usual fallback to the next alternative and the re-mirror path.
+
+The check is opt-in because it **doubles the number of registry requests** for every checked tag. Two things must be adjusted when enabling it:
+
+- **`routing.activeCheck.timeout`** — the two requests share a single timeout envelope, so the total is bounded to `timeout`, not `2 × timeout`. The `1s` default sizes one round-trip; give it at least `2s`–`3s` so both requests fit.
+- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
+
+```yaml
+routing:
+  activeCheck:
+    resolveDigest: true
+    timeout: 3s # two sequential requests share this budget
+
+monitoring:
+  registries:
+    items:
+      docker.io:
+        resolveDigest: true
+        interval: 1h
+        maxPerInterval: 3 # halved from 6, each check now costs two requests
+```
+
+`routing.activeCheck.resolveDigest` (webhook) and `monitoring.registries.*.resolveDigest` (`ClusterImageSetAvailability` probes) are independent, enable whichever surface you need. The per-registry value is a three-state boolean: unset inherits `monitoring.registries.default`, `false` opts a single registry out of an enabled default.
+
+> [!NOTE]
+> Registries that answer `405` or `501` to a manifest-by-digest request are treated as available. They support tag lookup but not the digest path for that HTTP method, and serve the image fine to container runtimes.
+
 ## Duplicated credential secrets (`kuik-kuik-...`)
 
 When a `(Cluster)ImageSetMirror` or `(Cluster)ReplicatedImageSet` declares a `credentialSecret`, kuik copies it into every namespace where a matching image is rerouted, naming the copy `kuik-<secret-name>-<hash>`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,8 +69,10 @@ type RegistryMonitoring struct {
 	FallbackCredentialSecret *kuikv1alpha1.CredentialSecret `koanf:"fallbackCredentialSecret"`
 }
 
-// ResolveDigestEnabled returns true when the digest-path check is enabled for
-// this registry. A nil ResolveDigest means unset (inherit / disabled).
+// ResolveDigestEnabled returns true when the digest-path check is explicitly
+// enabled for this registry. The three states are: nil = inherit from default
+// (treated as disabled until overridden), *false = explicitly disabled (overrides
+// an enabled default for this specific registry), *true = enabled.
 func (r *RegistryMonitoring) ResolveDigestEnabled() bool {
 	return r.ResolveDigest != nil && *r.ResolveDigest
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Routing struct {
 
 type ActiveCheck struct {
 	Timeout            time.Duration      `koanf:"timeout"`
+	ResolveDigest      bool               `koanf:"resolveDigest"`
 	StaleMirrorCleanup StaleMirrorCleanup `koanf:"staleMirrorCleanup"`
 }
 
@@ -64,7 +65,14 @@ type RegistryMonitoring struct {
 	Interval                 time.Duration                  `koanf:"interval"`
 	MaxPerInterval           int                            `koanf:"maxPerInterval"`
 	Timeout                  time.Duration                  `koanf:"timeout"`
+	ResolveDigest            *bool                          `koanf:"resolveDigest"`
 	FallbackCredentialSecret *kuikv1alpha1.CredentialSecret `koanf:"fallbackCredentialSecret"`
+}
+
+// ResolveDigestEnabled returns true when the digest-path check is enabled for
+// this registry. A nil ResolveDigest means unset (inherit / disabled).
+func (r *RegistryMonitoring) ResolveDigestEnabled() bool {
+	return r.ResolveDigest != nil && *r.ResolveDigest
 }
 
 type Metrics struct {

--- a/internal/controller/kuik/clusterimagesetavailability_controller.go
+++ b/internal/controller/kuik/clusterimagesetavailability_controller.go
@@ -256,6 +256,9 @@ func (r *ClusterImageSetAvailabilityReconciler) registryConfig(registry string) 
 		if override.Timeout != 0 {
 			merged.Timeout = override.Timeout
 		}
+		if override.ResolveDigest != nil {
+			merged.ResolveDigest = override.ResolveDigest
+		}
 		if override.FallbackCredentialSecret != nil {
 			merged.FallbackCredentialSecret = override.FallbackCredentialSecret
 		}
@@ -394,7 +397,7 @@ func (r *ClusterImageSetAvailabilityReconciler) performCheck(ctx context.Context
 		image.LastError = err.Error()
 	}
 
-	result, checkErr := registry.CheckImageAvailability(ctx, image.Image, registryConfig.Method, registryConfig.Timeout, pullSecrets)
+	result, checkErr := registry.CheckImageAvailability(ctx, image.Image, registryConfig.Method, registryConfig.Timeout, pullSecrets, registryConfig.ResolveDigestEnabled())
 	image.LastMonitor = &now
 
 	if image.Status == kuikv1alpha1.ImageAvailabilityUnavailableSecret && result == kuikv1alpha1.ImageAvailabilityInvalidAuth {

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -14,26 +16,98 @@ import (
 // and returns the availability status of the image along with any error encountered.
 // The error is non-nil for all non-Available statuses and contains the underlying
 // cause (e.g. HTTP status text, transport error).
-func CheckImageAvailability(ctx context.Context, reference string, method string, timeout time.Duration, pullSecrets []corev1.Secret) (kuikv1alpha1.ImageAvailabilityStatus, error) {
-	_, headers, err := NewClient(nil, nil).
+//
+// When resolveDigest is true and the reference is a tag, a second request (using
+// the same HTTP method) is made for the manifest digest the registry advertised
+// for that tag. This emulates the pull path of container runtimes (resolve tag
+// to digest, then fetch the manifest by digest) and catches registries that keep
+// answering tag requests while the manifest behind the digest is gone (typically
+// pull-through proxies with a stale tag cache): on such registries, tag HEAD/GET
+// return 200 but every node that does not already have the image in its local
+// store fails to pull.
+//
+// Note: when resolveDigest is true the check makes two requests, which doubles
+// rate-limit quota consumption for that image. Halve monitoring.registries.*.maxPerInterval
+// for rate-constrained registries (e.g. docker.io) when enabling this flag.
+func CheckImageAvailability(ctx context.Context, reference string, method string, timeout time.Duration, pullSecrets []corev1.Secret, resolveDigest bool) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	// When resolveDigest is enabled, both the tag and the by-digest requests must
+	// complete within a single shared timeout envelope so that the total wall time
+	// is bounded to `timeout`, not `2 × timeout`.
+	if resolveDigest && timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+		// Clear the per-call timeout on the client; the envelope context above
+		// is now the sole deadline for both requests.
+		timeout = 0
+	}
+
+	client := NewClient(nil, nil).
 		WithTimeout(timeout).
-		WithPullSecrets(pullSecrets).
-		ReadDescriptor(ctx, method, reference)
+		WithPullSecrets(pullSecrets)
+
+	desc, headers, err := client.ReadDescriptor(ctx, method, reference)
 
 	if IsRateLimited(headers) {
 		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded")
 	}
 
 	if err != nil {
-		switch TransportStatusCode(err) {
-		case http.StatusNotFound:
-			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
-		case http.StatusUnauthorized, http.StatusForbidden:
-			return kuikv1alpha1.ImageAvailabilityInvalidAuth, fmt.Errorf("authentication failed: %w", err)
-		default:
-			return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("registry unreachable: %w", err)
-		}
+		return availabilityFromError(err)
+	}
+
+	if resolveDigest {
+		return checkDigestPath(ctx, client, method, reference, desc)
 	}
 
 	return kuikv1alpha1.ImageAvailabilityAvailable, nil
+}
+
+// checkDigestPath verifies that the manifest digest advertised for a reference
+// can actually be fetched by digest. References that are already digest-addressed
+// are not checked again: the initial request covered the exact manifest the
+// runtime will pull.
+//
+// The same HTTP method used for the tag request is used for the digest request so
+// that registries requiring GET for manifest-by-digest are handled correctly.
+func checkDigestPath(ctx context.Context, client *Client, method string, reference string, desc *v1.Descriptor) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	ref, err := name.ParseReference(reference)
+	if err != nil {
+		// the initial request already succeeded for this reference, so this
+		// should never happen; report it rather than failing open
+		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("could not parse reference: %w", err)
+	}
+
+	if _, isDigest := ref.(name.Digest); isDigest || desc == nil {
+		return kuikv1alpha1.ImageAvailabilityAvailable, nil
+	}
+
+	digestReference := ref.Context().Name() + "@" + desc.Digest.String()
+	_, headers, err := client.ReadDescriptor(ctx, method, digestReference)
+
+	if IsRateLimited(headers) {
+		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded")
+	}
+
+	if err != nil {
+		if TransportStatusCode(err) == http.StatusNotFound {
+			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+		}
+		return availabilityFromError(err)
+	}
+
+	return kuikv1alpha1.ImageAvailabilityAvailable, nil
+}
+
+// availabilityFromError maps a registry transport error to an availability
+// status, wrapping the underlying cause.
+func availabilityFromError(err error) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	switch TransportStatusCode(err) {
+	case http.StatusNotFound:
+		return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return kuikv1alpha1.ImageAvailabilityInvalidAuth, fmt.Errorf("authentication failed: %w", err)
+	default:
+		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("registry unreachable: %w", err)
+	}
 }

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -78,6 +78,10 @@ func checkDigestPath(ctx context.Context, client *Client, method string, referen
 		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("could not parse reference: %w", err)
 	}
 
+	// Digest-addressed refs already targeted the exact manifest the runtime will
+	// pull, so no second request is needed. desc == nil is a defensive fallback:
+	// ReadDescriptor returned no error but no descriptor; skip digest verification
+	// and treat the image as available rather than failing open on a nil dereference.
 	if _, isDigest := ref.(name.Digest); isDigest || desc == nil {
 		return kuikv1alpha1.ImageAvailabilityAvailable, nil
 	}
@@ -90,8 +94,13 @@ func checkDigestPath(ctx context.Context, client *Client, method string, referen
 	}
 
 	if err != nil {
-		if TransportStatusCode(err) == http.StatusNotFound {
+		switch TransportStatusCode(err) {
+		case http.StatusNotFound:
 			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
+			// The registry supports tag lookup but not manifest-by-digest for this
+			// HTTP method; the tag check already passed so the image is pullable.
+			return kuikv1alpha1.ImageAvailabilityAvailable, nil
 		}
 		return availabilityFromError(err)
 	}

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -96,7 +96,7 @@ func checkDigestPath(ctx context.Context, client *Client, method string, referen
 	if err != nil {
 		switch TransportStatusCode(err) {
 		case http.StatusNotFound:
-			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest: %w", reference, desc.Digest.String(), err)
 		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
 			// The registry supports tag lookup but not manifest-by-digest for this
 			// HTTP method; the tag check already passed so the image is pullable.

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -16,26 +16,49 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
-// brokenDigestRegistry wraps an in-memory registry and can be set to return
-// 404 for manifest requests by digest while keeping tag requests working.
-// This reproduces a pull-through proxy with a stale tag cache: tags keep
-// resolving (HEAD and GET return 200 with a Docker-Content-Digest header),
-// but the manifests behind those digests are gone, so container runtimes
-// fail to pull on any node that does not already have the image.
+// digestResponseMode controls how brokenDigestRegistry responds to manifest-by-digest requests.
+type digestResponseMode int
+
+const (
+	digestResponseNormal           digestResponseMode = iota // pass through to the real registry
+	digestResponseNotFound                                   // 404 — stale tag cache / blocked by policy
+	digestResponseRateLimit                                  // 429 with RateLimit-Remaining: 0 header
+	digestResponseUnauthorized                               // 401 — fine-grained auth on digest path
+	digestResponseMethodNotAllowed                           // 405 — proxy supports tags but not digest lookup
+)
+
+// brokenDigestRegistry wraps an in-memory registry and can intercept manifest-by-digest
+// requests to simulate various proxy and registry failure modes while keeping tag requests
+// working. Subtests must not run in parallel because digestMode is shared state.
 type brokenDigestRegistry struct {
 	handler       http.Handler
-	brokenDigests atomic.Bool
+	digestMode    atomic.Int32 // stores digestResponseMode
 	manifestReads atomic.Int64
 }
 
 func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.URL.Path, "/manifests/") && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
 		b.manifestReads.Add(1)
-		if b.brokenDigests.Load() && strings.Contains(r.URL.Path, "/manifests/sha256:") {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
-			return
+		if strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			switch digestResponseMode(b.digestMode.Load()) {
+			case digestResponseNotFound:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
+				return
+			case digestResponseRateLimit:
+				w.Header().Set("RateLimit-Remaining", "0;w=21600")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			case digestResponseUnauthorized:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`)
+				return
+			case digestResponseMethodNotAllowed:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 		}
 	}
 	b.handler.ServeHTTP(w, r)
@@ -66,7 +89,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 		name          string
 		reference     string
 		method        string
-		brokenDigests bool
+		digestMode    digestResponseMode
 		resolveDigest bool
 		want          kuikv1alpha1.ImageAvailabilityStatus
 		wantErr       string
@@ -96,18 +119,18 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			wantReads:     2,
 		},
 		{
-			name:          "broken digests without digest resolution stay invisible",
-			reference:     tagReference,
-			method:        http.MethodHead,
-			brokenDigests: true,
-			want:          kuikv1alpha1.ImageAvailabilityAvailable,
-			wantReads:     1,
+			name:       "broken digests without digest resolution stay invisible",
+			reference:  tagReference,
+			method:     http.MethodHead,
+			digestMode: digestResponseNotFound,
+			want:       kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:  1,
 		},
 		{
 			name:          "broken digests with digest resolution HEAD are detected",
 			reference:     tagReference,
 			method:        http.MethodHead,
-			brokenDigests: true,
+			digestMode:    digestResponseNotFound,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityNotFound,
 			wantErr:       "tag/digest inconsistency",
@@ -117,7 +140,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			name:          "broken digests with digest resolution GET are detected",
 			reference:     tagReference,
 			method:        http.MethodGet,
-			brokenDigests: true,
+			digestMode:    digestResponseNotFound,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityNotFound,
 			wantErr:       "tag/digest inconsistency",
@@ -131,11 +154,40 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			want:          kuikv1alpha1.ImageAvailabilityAvailable,
 			wantReads:     1,
 		},
+		{
+			name:          "rate limit on digest path returns QuotaExceeded",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseRateLimit,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityQuotaExceeded,
+			wantErr:       "rate limit exceeded",
+			wantReads:     2,
+		},
+		{
+			name:          "auth failure on digest path returns InvalidAuth",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseUnauthorized,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityInvalidAuth,
+			wantErr:       "authentication failed",
+			wantReads:     2,
+		},
+		{
+			name:          "digest method not allowed returns Available",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseMethodNotAllowed,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake.brokenDigests.Store(tt.brokenDigests)
+			fake.digestMode.Store(int32(tt.digestMode))
 			readsBefore := fake.manifestReads.Load()
 
 			method := tt.method
@@ -157,7 +209,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 				}
 			}
 			if reads := fake.manifestReads.Load() - readsBefore; reads != tt.wantReads {
-				t.Errorf("manifest read requests = %d, want %d", reads, tt.wantReads)
+				t.Errorf("manifest read requests = %d, want %d (ref=%s method=%s resolveDigest=%v)", reads, tt.wantReads, tt.reference, tt.method, tt.resolveDigest)
 			}
 		})
 	}

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -1,0 +1,164 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+// brokenDigestRegistry wraps an in-memory registry and can be set to return
+// 404 for manifest requests by digest while keeping tag requests working.
+// This reproduces a pull-through proxy with a stale tag cache: tags keep
+// resolving (HEAD and GET return 200 with a Docker-Content-Digest header),
+// but the manifests behind those digests are gone, so container runtimes
+// fail to pull on any node that does not already have the image.
+type brokenDigestRegistry struct {
+	handler       http.Handler
+	brokenDigests atomic.Bool
+	manifestReads atomic.Int64
+}
+
+func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "/manifests/") && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		b.manifestReads.Add(1)
+		if b.brokenDigests.Load() && strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
+			return
+		}
+	}
+	b.handler.ServeHTTP(w, r)
+}
+
+func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
+	fake := &brokenDigestRegistry{handler: registry.New()}
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	tagReference := host + "/test/image:latest"
+
+	image, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crane.Push(image, tagReference); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestReference := host + "/test/image@" + digest.String()
+
+	tests := []struct {
+		name          string
+		reference     string
+		method        string
+		brokenDigests bool
+		resolveDigest bool
+		want          kuikv1alpha1.ImageAvailabilityStatus
+		wantErr       string
+		wantReads     int64
+	}{
+		{
+			name:      "healthy registry without digest resolution",
+			reference: tagReference,
+			method:    http.MethodHead,
+			want:      kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads: 1,
+		},
+		{
+			name:          "healthy registry with digest resolution HEAD",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "healthy registry with digest resolution GET",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "broken digests without digest resolution stay invisible",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			brokenDigests: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     1,
+		},
+		{
+			name:          "broken digests with digest resolution HEAD are detected",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			brokenDigests: true,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityNotFound,
+			wantErr:       "tag/digest inconsistency",
+			wantReads:     2,
+		},
+		{
+			name:          "broken digests with digest resolution GET are detected",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			brokenDigests: true,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityNotFound,
+			wantErr:       "tag/digest inconsistency",
+			wantReads:     2,
+		},
+		{
+			name:          "digest reference is not checked twice",
+			reference:     digestReference,
+			method:        http.MethodHead,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.brokenDigests.Store(tt.brokenDigests)
+			readsBefore := fake.manifestReads.Load()
+
+			method := tt.method
+			if method == "" {
+				method = http.MethodHead
+			}
+			got, err := CheckImageAvailability(context.Background(), tt.reference, method, 5*time.Second, nil, tt.resolveDigest)
+
+			if got != tt.want {
+				t.Errorf("status = %v, want %v (err: %v)", got, tt.want, err)
+			}
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+			}
+			if reads := fake.manifestReads.Load() - readsBefore; reads != tt.wantReads {
+				t.Errorf("manifest read requests = %d, want %d", reads, tt.wantReads)
+			}
+		})
+	}
+}

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -44,7 +44,7 @@ func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			case digestResponseNotFound:
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusNotFound)
-				fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
+				_, _ = fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
 				return
 			case digestResponseRateLimit:
 				w.Header().Set("RateLimit-Remaining", "0;w=21600")
@@ -53,7 +53,7 @@ func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			case digestResponseUnauthorized:
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
-				fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`)
+				_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`)
 				return
 			case digestResponseMethodNotAllowed:
 				w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -613,7 +613,7 @@ func (d *PodCustomDefaulter) checkImageAvailabilityCached(ctx context.Context, i
 	err, _ := d.requestGroup.Do("availability:"+image.Reference, func() (any, error) {
 		log := logf.FromContext(ctx, "reference", image.Reference)
 
-		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets)
+		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets, d.Config.Routing.ActiveCheck.ResolveDigest)
 		if err != nil {
 			log.V(1).Info("image is not available", "error", err)
 		} else {

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -612,7 +612,7 @@ func (d *PodCustomDefaulter) checkImageAvailabilityCached(ctx context.Context, i
 	err, _ := d.requestGroup.Do("availability:"+image.Reference, func() (any, error) {
 		log := logf.FromContext(ctx, "reference", image.Reference)
 
-		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets)
+		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets, d.Config.Routing.ActiveCheck.ResolveDigest)
 		if err != nil {
 			log.V(1).Info("image is not available", "error", err)
 		} else {


### PR DESCRIPTION
Closes #626.

## Approach

Follow the same two-step path container runtimes use: resolve the tag to a digest, then verify the manifest exists by that digest. A 404 on the digest path surfaces as `ImageAvailabilityNotFound` with a `tag/digest inconsistency` message, triggering the normal fallback and re-mirror path.

The check is opt-in (`resolveDigest: false` by default) because it doubles the number of registry requests per image. Existing deployments are unaffected until the flag is set.

405/501 from the digest request is treated as `Available` — proxies that support tag lookup but not manifest-by-digest still serve the image fine to container runtimes.

## Configuration

```yaml
# Webhook active-check (adds one round-trip per image on first admission)
routing:
  activeCheck:
    resolveDigest: true
    timeout: 3s  # recommended minimum; default 1s covers one request, not two

# Per-registry monitoring (doubles request quota — halve maxPerInterval accordingly)
monitoring:
  registries:
    items:
      docker.io:
        resolveDigest: true
        interval: 1h
        maxPerInterval: 3  # halved from 6
```

Per-registry `resolveDigest` is a nullable bool: `null`/unset inherits the global default, `false` disables for that registry, `true` enables.

## Changes

- `internal/registry/availability.go` — `CheckImageAvailability` gains `resolveDigest bool`; new `checkDigestPath` helper performs the second request and maps errors to typed statuses.
- `internal/config/config.go` — `ActiveCheck.ResolveDigest bool` (global) and `RegistryMonitoring.ResolveDigest *bool` (per-registry, three-state).
- `internal/controller/kuik/clusterimagesetavailability_controller.go` — merges per-registry override and passes resolved flag to availability check.
- `internal/webhook/core/v1/pod_webhook.go` — passes global flag to availability check.
- `internal/registry/availability_test.go` _(new)_ — table-driven suite: healthy/broken digest paths, rate-limit and auth-failure on the digest path, 405 from HEAD-only proxies, digest reference not rechecked.
- `website/src/content/docs/configuration.md` — documents both config keys with rate-limit and timeout guidance.

## Test plan

- [x] `go test ./internal/registry/...` — 11/11 cases pass
- [x] `make test` — full suite green
- [ ] Manual: cluster with Artifactory/Xray, verify `NotFound` returned for tag whose digest is blocked

## AI disclosure

AI tools were used to assist in drafting this contribution. All changes have been reviewed, understood, and verified by the human author.