### PR TITLE
docs: simplify github landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 **kuik** (pronounced /kwɪk/, like "quick") is the shortname of **kube-image-keeper**.
 
-Its primary objective is to **maximize the availability of Pod images** within a Kubernetes cluster.
+✅ Its primary objective is to **maximize the availability of Pod images** within a Kubernetes cluster.
 
-Its secondary goal is to ensure **bulletproof reliability** by keeping the manipulation of Kubernetes primitives to an absolute minimum.
+✅ Its secondary goal is to ensure **bulletproof reliability** by keeping the manipulation of Kubernetes primitives to an absolute minimum.
 
 ## Under the hood
 
@@ -36,7 +36,7 @@ Developed by Enix, kube-image-keeper is a battle-tested solution currently runni
 We rely on [cert-manager Custom Resources](./helm/kube-image-keeper/templates/webhook-certificate.yaml) to manage the kuik mutating webhook certificate, so you need to [install it first](https://cert-manager.io/docs/installation/).
 
 ```bash
-VERSION=2.2.2
+VERSION=2.2.3
 helm upgrade --install --create-namespace --namespace kuik-system kube-image-keeper oci://quay.io/enix/charts/kube-image-keeper:$VERSION
 ```
 
@@ -54,8 +54,7 @@ If you let kuik cleanup expired images in your registry, you still have to confi
 
 ## 📅 Releases & Roadmap
 
-> [!NOTE]
-> Kuik v2 has reached **General Availability** and is **Production Ready** as of v2.2.2 🚀
+Kuik v2 has reached **General Availability** and is **Production Ready** as of v2.2.2 🚀
 
 ### Already available
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@
 
 **kuik** (pronounced /kwɪk/, like "quick") is the shortname of **kube-image-keeper**.
 
-Its primary objective is to maximize the availability of Pod images within a Kubernetes cluster.
-Its secondary goal is to ensure bulletproof reliability by keeping the manipulation of Kubernetes primitives to an absolute minimum.
+Its primary objective is to **maximize the availability of Pod images** within a Kubernetes cluster.
+
+Its secondary goal is to ensure **bulletproof reliability** by keeping the manipulation of Kubernetes primitives to an absolute minimum.
 
 ## Under the hood
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 Its primary objective is to maximize the availability of Pod images within a Kubernetes cluster.
 Its secondary goal is to ensure bulletproof reliability by keeping the manipulation of Kubernetes primitives to an absolute minimum.
 
-From a technical standpoint, kuik operates as a lightweight webhook that automatically rewrites image paths whenever the source registry becomes unavailable.
+## Under the hood
 
-Under the hood, kuik relies on three core mechanisms:
+kuik operates as a lightweight webhook that automatically rewrites image paths whenever the source registry becomes unavailable.
+
+It relies on three core mechanisms:
 - **Image routing**: rewrites Pod image paths on the fly to redirect them to a functional registry.
 - **Image copy**: mirror images between registries to build a virtual, highly available registry.
 - **Image monitoring**: continuously tracks the availability of Pod images across various registries.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Developed by Enix, kube-image-keeper is a battle-tested solution currently runni
 
 ## Table of contents
 
-📖 **Documentation, concepts and use cases are available here: [kuik.enix.io](https://kuik.enix.io)**
+Documentation, concepts and use cases are available here: [kuik.enix.io](https://kuik.enix.io)
 
 - [Get started](#-get-started)
 - [Releases & Roadmap](#-releases--roadmap)

--- a/README.md
+++ b/README.md
@@ -5,105 +5,30 @@
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Brought to you by Enix](https://img.shields.io/badge/Brought%20to%20you%20by-ENIX-%23377dff?labelColor=888&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAQAAAC1QeVaAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElNRQfkBAkQIg/iouK/AAABZ0lEQVQY0yXBPU8TYQDA8f/zcu1RSDltKliD0BKNECYZmpjgIAOLiYtubn4EJxI/AImzg3E1+AGcYDIMJA7lxQQQQRAiSSFG2l457+655x4Gfz8B45zwipWJ8rPCQ0g3+p9Pj+AlHxHjnLHAbvPW2+GmLoBN+9/+vNlfGeU2Auokd8Y+VeYk/zk6O2fP9fcO8hGpN/TUbxpiUhJiEorTgy+6hUlU5N1flK+9oIJHiKNCkb5wMyOFw3V9o+zN69o0Exg6ePh4/GKr6s0H72Tc67YsdXbZ5gENNjmigaXbMj0tzEWrZNtqigva5NxjhFP6Wfw1N1pjqpFaZQ7FAY6An6zxTzHs0BGqY/NQSnxSBD6WkDRTf3O0wG2Ztl/7jaQEnGNxZMdy2yET/B2xfGlDagQE1OgRRvL93UOHqhLnesPKqJ4NxLLn2unJgVka/HBpbiIARlHFq1n/cWlMZMne1ZfyD5M/Aa4BiyGSwP4Jl3UAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjAtMDQtMDlUMTQ6MzQ6MTUrMDI6MDDBq8/nAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIwLTA0LTA5VDE0OjM0OjE1KzAyOjAwsPZ3WwAAAABJRU5ErkJggg==)](https://enix.io)
 
-**kuik** (pronounced /kwɪk/, like "quick") is the shortname of **kube-image-keeper**, a container image routing, mirroring (caching) and replication system for Kubernetes developed by Enix. It helps make applications more highly available by ensuring reliable access to container images.
+**kuik** (pronounced /kwɪk/, like "quick") is the shortname of **kube-image-keeper**.
 
-> [!NOTE]
-> Kuik v2 has reached **General Availability** and is **Production Ready** as of v2.2.2 🚀
+Its primary objective is to maximize the availability of Pod images within a Kubernetes cluster.
+Its secondary goal is to ensure bulletproof reliability by keeping the manipulation of Kubernetes primitives to an absolute minimum.
 
-📖 **Full documentation: [kuik.enix.io](https://kuik.enix.io)**
+From a technical standpoint, kuik operates as a lightweight webhook that automatically rewrites image paths whenever the source registry becomes unavailable.
+
+Under the hood, kuik relies on three core mechanisms:
+- **Image routing**: rewrites Pod image paths on the fly to redirect them to a functional registry.
+- **Image copy**: mirror images between registries to build a virtual, highly available registry.
+- **Image monitoring**: continuously tracks the availability of Pod images across various registries.
+
+Developed by Enix, kube-image-keeper is a battle-tested solution currently running in production across multiple Kubernetes clusters.
 
 ## Table of contents
 
-- [Introduction](#introduction)
-- [When to use Kube Image Keeper](#when-to-use-kube-image-keeper)
+📖 **Documentation, concepts and use cases are available here: [kuik.enix.io](https://kuik.enix.io)**
+
+- [Get started](#-get-started)
 - [Releases & Roadmap](#-releases--roadmap)
 - [Known limitations to date](#-known-limitations-to-date)
-- [Installation](#-installation)
 - [Why Version 2?](#why-version-2)
 
-## Introduction
-
-kuik v2 is a **complete rewrite** of the project with a focus on **simplicity** and **ease of use** :
-
-- **Minimal default features**: only core functionality enabled by default, others opt-in.
-- **Image routing**: Kuik can rewrite Pod images on-the-fly to redirect them to an operational registry.
-- **Image copy**: Kuik manages image transfers between registries in order to create a virtual, highly-available registry.
-- **Image monitoring**: Kuik tracks image availability across various registries.
-- **Redesigned CRDs**: for better clarity and improved extensibility.
-
-### Concept : Container image alternative
-
-KuiK utilizes a **mutating webhook** to rewrite Pod container images when the primary ("original") source is not available.
-By leveraging [*ImageSetMirror* or *ReplicatedImageSet*](./docs/crds.md) Custom Resources, Kuik generates a list of **alternative** image locations (including the **original** one). It then validates their availability to determine whether to stick with the **original** image or rewrite the manifest to a healthy alternative.
-
-While both Custom Resources generate alternatives, their behavior differs slightly:
-
-- *ReplicatedImageSet*: Focuses on checking availability across existing mirrors.
-- *ImageSetMirror*: Also handles the **automated copy** of the original image to the specified mirror registry.
-
-## When to use Kube Image Keeper
-
-### ✅ Overcome public registry limitations
-
-- You face an image pull rate limit
-- Your upstream registry is no longer available
-
-&emsp;[Implementation guide](./docs/use-cases/overcome-public-registry-limitations.md)
-
-### ✅ Detect missing images before outage
-
-- You plan a maintenance which will reschedule a lot of pods on new workers
-- You plan a Kubernetes upgrade
-- You have a lot of legacy images deployed on your cluster
-
-&emsp;[Implementation guide](./docs/use-cases/detect-missing-images-before-outage.md)
-
-### ✅ Protect images from garbage collect
-
-- You have an aggressive garbage collect
-- You have plenty of images (outdated, prior versions, development version) but only a small fraction is being used in reality
-- You would like to push only a subset of useful images to your production registry
-
-&emsp;[Implementation guide](./docs/use-cases/protect-images-from-garbage-collection.md)
-
-### ✅ Automatically route images to a proxy cache registry
-
-- You already have setup a proxy cache registry (like Harbor or Gitlab proxy cache) but do not know how to use it
-- You do not want to review all workloads deployments (and change their image path)
-
-&emsp;[Implementation guide](./docs/use-cases/automatically-route-images-to-a-proxy-cache-registry.md)
-
-### ✅ Better performance with local registry
-
-- You use a development registry (ex: gitlab, maven, ...) for production Kubernetes clusters.
-- Your registry is overloaded.
-- Image pull from Kubernetes are too slow / long.
-- Your source registry is too far away (from a network / geographic / latency standpoint) from the Kubernetes cluster
-
-&emsp;[Implementation guide](./docs/use-cases/better-performance-with-local-registry.md)
-
-## 📅 Releases & Roadmap
-
-### Already available
-
-- [**v2.0**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.0) We announced the launch of version 2.0 (General Availability) at the [Cloud Native Days France 2026 convention](https://www.cloudnativedays.fr/)
-- [**v2.1**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.0) Priorities for routing and replication are now a thing
-  - [**v2.1.1**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.1) Fix concurrent access to a single registry (in particular regarding the garbage collect mechanism) by multiple Kuik instances on multiple clusters
-- [**v2.2**](https://github.com/enix/kube-image-keeper/releases/tag/v2.2.0) Complete implementation of the **Image monitoring** feature with associated metrics
-
-### Planned features
-
-- [**v2.3** Better filtering](https://github.com/enix/kube-image-keeper/milestone/1)
-- [**v2.4** Complete OCI support of tags, architectures and digests](https://github.com/enix/kube-image-keeper/milestone/3)
-- [**v2.5** Improve stability & efficiancy](https://github.com/enix/kube-image-keeper/milestone/2)
-
-## 🚧 Known limitations to date
-
-- The mutating webhook do not support the Pod `Update` call
-- Digest tags are not supported, ex: `@sha256:cb4e4ffc5789fd5ff6a534e3b1460623df61cba00f5ea1c7b40153b5efb81805`
-- Per-platform mirroring status is not tracked in the (Cluster)ImageSetMirror status. As a result: (1) Kuik cannot report which architectures are actually mirrored for a given image — a mirror is marked successful as long as at least one configured platform is available, and missing platforms are only logged as a warning; and (2) changing `mirroring.platforms` after images have been mirrored does not re-mirror or clean up already-copied manifests (added or removed platforms only apply to subsequent mirror operations)
-
-## 📦 Installation
+## 🚀 Get started
 
 We rely on [cert-manager Custom Resources](./helm/kube-image-keeper/templates/webhook-certificate.yaml) to manage the kuik mutating webhook certificate, so you need to [install it first](https://cert-manager.io/docs/installation/).
 
@@ -123,6 +48,30 @@ kubectl create secret docker-registry my-registry-secret --docker-server=my-regi
 ```
 
 If you let kuik cleanup expired images in your registry, you still have to configure garbage collection on your own as kuik only delete images reference.
+
+## 📅 Releases & Roadmap
+
+> [!NOTE]
+> Kuik v2 has reached **General Availability** and is **Production Ready** as of v2.2.2 🚀
+
+### Already available
+
+- [**v2.0**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.0) We announced the launch of version 2.0 (General Availability) at the [Cloud Native Days France 2026 convention](https://www.cloudnativedays.fr/)
+- [**v2.1**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.0) Priorities for routing and replication are now a thing
+  - [**v2.1.1**](https://github.com/enix/kube-image-keeper/releases/tag/v2.1.1) Fix concurrent access to a single registry (in particular regarding the garbage collect mechanism) by multiple Kuik instances on multiple clusters
+- [**v2.2**](https://github.com/enix/kube-image-keeper/releases/tag/v2.2.0) Complete implementation of the **Image monitoring** feature with associated metrics
+
+### Planned features
+
+- [**v2.3** Better filtering](https://github.com/enix/kube-image-keeper/milestone/1)
+- [**v2.4** Complete OCI support of tags, architectures and digests](https://github.com/enix/kube-image-keeper/milestone/3)
+- [**v2.5** Improve stability & efficiancy](https://github.com/enix/kube-image-keeper/milestone/2)
+
+## 🚧 Known limitations to date
+
+- The mutating webhook do not support the Pod `Update` call
+- Digest tags are not supported, ex: `@sha256:cb4e4ffc5789fd5ff6a534e3b1460623df61cba00f5ea1c7b40153b5efb81805`
+- Per-platform mirroring status is not tracked in the (Cluster)ImageSetMirror status. As a result: (1) Kuik cannot report which architectures are actually mirrored for a given image — a mirror is marked successful as long as at least one configured platform is available, and missing platforms are only logged as a warning; and (2) changing `mirroring.platforms` after images have been mirrored does not re-mirror or clean up already-copied manifests (added or removed platforms only apply to subsequent mirror operations)
 
 ## Why Version 2?
 

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 2
+---
+
 # Development
 
 ```bash

--- a/docs/guides/v1-to-v2-migration-path.md
+++ b/docs/guides/v1-to-v2-migration-path.md
@@ -1,3 +1,8 @@
+---
+sidebar:
+  order: 1
+---
+
 # v1 to v2 migration path
 
 kube-image-keeper v1 is reaching end of life and will not be maintained anymore. This document describes the key differences between v1 and v2 and how to migrate your setup.


### PR DESCRIPTION
Details are now available through other markdown files and the kuik.enix.io website

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README.md with a clearer "Get started" section and updated Helm installation example for version 2.2.3.
  * Added cert-manager webhook certificate prerequisites to getting started guidance.
  * Improved documentation navigation structure across guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->