### PR TITLE
feat(mirroring): Add support for pullCredentialSecret

### DIFF
--- a/api/kuik/v1alpha1/imagesetmirror_types.go
+++ b/api/kuik/v1alpha1/imagesetmirror_types.go
@@ -84,7 +84,11 @@ type Mirror struct {
 	Registry         string            `json:"registry,omitempty"`
 	Path             string            `json:"path,omitempty"`
 	CredentialSecret *CredentialSecret `json:"credentialSecret,omitempty"`
-	Cleanup          *Cleanup          `json:"cleanup,omitempty"`
+	// PullCredentialSecret will be the secret used by Pods to pull images from this mirror.
+	// If not set, it will default to using CredentialSecret instead.
+	// This is used to prevent the creation/deletion secret from being compromised by being copied to other Namespaces.
+	PullCredentialSecret *CredentialSecret `json:"pullCredentialSecret,omitempty"`
+	Cleanup              *Cleanup          `json:"cleanup,omitempty"`
 }
 
 type Mirrors []Mirror

--- a/api/kuik/v1alpha1/zz_generated.deepcopy.go
+++ b/api/kuik/v1alpha1/zz_generated.deepcopy.go
@@ -629,6 +629,11 @@ func (in *Mirror) DeepCopyInto(out *Mirror) {
 		*out = new(CredentialSecret)
 		**out = **in
 	}
+	if in.PullCredentialSecret != nil {
+		in, out := &in.PullCredentialSecret, &out.PullCredentialSecret
+		*out = new(CredentialSecret)
+		**out = **in
+	}
 	if in.Cleanup != nil {
 		in, out := &in.Cleanup, &out.Cleanup
 		*out = new(Cleanup)

--- a/config/crd/bases/kuik.enix.io_clusterimagesetmirrors.yaml
+++ b/config/crd/bases/kuik.enix.io_clusterimagesetmirrors.yaml
@@ -183,6 +183,21 @@ spec:
                         0 means no specific ordering (YAML declaration order is preserved).
                         Positive values are sorted ascending: lower value = higher priority.
                       type: integer
+                    pullCredentialSecret:
+                      description: |-
+                        PullCredentialSecret will be the secret used by Pods to pull images from this mirror.
+                        If not set, it will default to using CredentialSecret instead.
+                        This is used to prevent the creation/deletion secret from being compromised by being copied to other Namespaces.
+                      properties:
+                        name:
+                          description: Name is the name of the secret
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace where the secret is located.
+                            This value is ignored for namespaced resources and the namespace of the parent object is used instead.
+                          type: string
+                      type: object
                     registry:
                       type: string
                   type: object

--- a/config/crd/bases/kuik.enix.io_imagesetmirrors.yaml
+++ b/config/crd/bases/kuik.enix.io_imagesetmirrors.yaml
@@ -178,6 +178,21 @@ spec:
                         0 means no specific ordering (YAML declaration order is preserved).
                         Positive values are sorted ascending: lower value = higher priority.
                       type: integer
+                    pullCredentialSecret:
+                      description: |-
+                        PullCredentialSecret will be the secret used by Pods to pull images from this mirror.
+                        If not set, it will default to using CredentialSecret instead.
+                        This is used to prevent the creation/deletion secret from being compromised by being copied to other Namespaces.
+                      properties:
+                        name:
+                          description: Name is the name of the secret
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace where the secret is located.
+                            This value is ignored for namespaced resources and the namespace of the parent object is used instead.
+                          type: string
+                      type: object
                     registry:
                       type: string
                   type: object

--- a/docs/crds.md
+++ b/docs/crds.md
@@ -108,6 +108,9 @@ The `ImageSetMirror` and `ClusterImageSetMirror` resources define the actual mir
 | `spec.mirrors[].credentialSecret` | | Reference to a Secret used to push images to this mirror. |
 | `spec.mirrors[].credentialSecret.name` | | Name of the Secret. |
 | `spec.mirrors[].credentialSecret.namespace` | | Namespace of the Secret. Ignored for namespaced `ImageSetMirror` (uses the parent namespace instead). |
+| `spec.mirrors[].pullCredentialSecret` | | Reference to a Secret used to pull images from this mirror. If not set, will use credentialSecret instead. |
+| `spec.mirrors[].pullCredentialSecret.name` | | Name of the Secret. |
+| `spec.mirrors[].pullCredentialSecret.namespace` | | Namespace of the Secret. Ignored for namespaced `ImageSetMirror` (uses the parent namespace instead). |
 | `spec.mirrors[].cleanup` | | Per-mirror cleanup strategy override. Same fields as `spec.cleanup`. |
 
 ### Example
@@ -129,6 +132,9 @@ spec:
     credentialSecret:
       name: registry-secret
       namespace: kuik-system
+    pullCredentialSecret:
+      name: registry-pull-secret
+      namespace: kuik-system
   cleanup:
     enabled: true
     retention: 24h
@@ -142,7 +148,7 @@ kubectl -n kuik-system create secret docker-registry registry-secret --docker-se
 
 When cleanup is enabled, kuik only delete mirror image reference once an image is no longer running in the cluster since more than `retention` time (useful to deal with image used by CronJobs). You still have to configure garbage collection on your registry to actually reclaim space.
 
-If an image is rewritten to use our mirror, kuik will copy the secret to the pod's namespace and add it to pod `imagePullSecrets`.
+If an image is rewritten to use our mirror, kuik will copy the pullCredentialSecret to the pod's namespace and add it to pod `imagePullSecrets`.
 
 ## ClusterImageSetAvailability
 

--- a/docs/use-cases/better-performance-with-local-registry.md
+++ b/docs/use-cases/better-performance-with-local-registry.md
@@ -42,4 +42,7 @@ spec:
     credentialSecret:
       name: local-registry-secret
       namespace: default
+    pullCredentialSecret:
+      name: local-registry-pull-secret
+      namespace: default
 ```

--- a/helm/kube-image-keeper/crds/kuik.enix.io_clusterimagesetmirrors.yaml
+++ b/helm/kube-image-keeper/crds/kuik.enix.io_clusterimagesetmirrors.yaml
@@ -182,6 +182,21 @@ spec:
                         0 means no specific ordering (YAML declaration order is preserved).
                         Positive values are sorted ascending: lower value = higher priority.
                       type: integer
+                    pullCredentialSecret:
+                      description: |-
+                        PullCredentialSecret will be the secret used by Pods to pull images from this mirror.
+                        If not set, it will default to using CredentialSecret instead.
+                        This is used to prevent the creation/deletion secret from being compromised by being copied to other Namespaces.
+                      properties:
+                        name:
+                          description: Name is the name of the secret
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace where the secret is located.
+                            This value is ignored for namespaced resources and the namespace of the parent object is used instead.
+                          type: string
+                      type: object
                     registry:
                       type: string
                   type: object

--- a/helm/kube-image-keeper/crds/kuik.enix.io_imagesetmirrors.yaml
+++ b/helm/kube-image-keeper/crds/kuik.enix.io_imagesetmirrors.yaml
@@ -177,6 +177,21 @@ spec:
                         0 means no specific ordering (YAML declaration order is preserved).
                         Positive values are sorted ascending: lower value = higher priority.
                       type: integer
+                    pullCredentialSecret:
+                      description: |-
+                        PullCredentialSecret will be the secret used by Pods to pull images from this mirror.
+                        If not set, it will default to using CredentialSecret instead.
+                        This is used to prevent the creation/deletion secret from being compromised by being copied to other Namespaces.
+                      properties:
+                        name:
+                          description: Name is the name of the secret
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace where the secret is located.
+                            This value is ignored for namespaced resources and the namespace of the parent object is used instead.
+                          type: string
+                      type: object
                     registry:
                       type: string
                   type: object

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -302,6 +302,9 @@ func (d *PodCustomDefaulter) defaultPod(ctx context.Context, pod *corev1.Pod, dr
 			if mirror.CredentialSecret != nil {
 				mirror.CredentialSecret.Namespace = ism.Namespace
 			}
+			if mirror.PullCredentialSecret != nil {
+				mirror.PullCredentialSecret.Namespace = ism.Namespace
+			}
 		}
 		imageSetMirrors = append(imageSetMirrors, ism)
 	}
@@ -551,9 +554,14 @@ func (d *PodCustomDefaulter) buildAlternativesList(ctx context.Context, imageSet
 			}
 
 			for declarationIdx, mirror := range ism.Spec.Mirrors {
+				pullSecret := mirror.CredentialSecret
+				if mirror.PullCredentialSecret != nil {
+					pullSecret = mirror.PullCredentialSecret
+				}
+
 				alternatives = append(alternatives, prioritizedAlternative{
 					reference:        path.Join(mirror.Registry, mirror.Path, imgPath),
-					credentialSecret: mirror.CredentialSecret,
+					credentialSecret: pullSecret,
 					secretOwner:      ism,
 					crPriority:       ism.Spec.Priority,
 					intraPriority:    mirror.Priority,

--- a/internal/webhook/core/v1/pod_webhook_test.go
+++ b/internal/webhook/core/v1/pod_webhook_test.go
@@ -418,6 +418,23 @@ var _ = Describe("buildAlternativesList", func() {
 		}
 	}
 
+	createSecret := func(name string, namespace string) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				".dockerconfigjson": []byte(`{"auths":{"harbor.example.com":{"username":"user","password":"pass"}}}`),
+			},
+		}
+		Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, secret)
+		})
+	}
+
 	cismWithMirror := func(priority int, registry, mirrorPath string) kuikv1alpha1.ImageSetMirror {
 		return kuikv1alpha1.ImageSetMirror{
 			ObjectMeta: metav1.ObjectMeta{Name: "global"},
@@ -684,6 +701,47 @@ var _ = Describe("buildAlternativesList", func() {
 				"harbor.example.com/mirror/library/nginx:1.29",
 				"docker.io/library/nginx:1.29",
 			}))
+		})
+
+		It("uses the credentialSecret when no pullCredentialSecret is present", func() {
+			c := makeContainer("docker.io/library/nginx:1.29", corev1.PullIfNotPresent)
+			cism := cismWithMirror(-1, "harbor.example.com", "/mirror")
+			createSecret("harbor-cred", "default")
+			cism.Spec.Mirrors[0].CredentialSecret = &kuikv1alpha1.CredentialSecret{
+				Name:      "harbor-cred",
+				Namespace: "default",
+			}
+			err := d.buildAlternativesList(
+				ctx,
+				[]kuikv1alpha1.ImageSetMirror{cism},
+				nil,
+				c,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Images[0].CredentialSecret.Name).To(Equal("harbor-cred"))
+		})
+
+		It("uses the pullCredentialSecret when present", func() {
+			c := makeContainer("docker.io/library/nginx:1.29", corev1.PullIfNotPresent)
+			cism := cismWithMirror(-1, "harbor.example.com", "/mirror")
+			createSecret("harbor-cred", "default")
+			cism.Spec.Mirrors[0].CredentialSecret = &kuikv1alpha1.CredentialSecret{
+				Name:      "harbor-cred",
+				Namespace: "default",
+			}
+			createSecret("harbor-pull-cred", "default")
+			cism.Spec.Mirrors[0].PullCredentialSecret = &kuikv1alpha1.CredentialSecret{
+				Name:      "harbor-pull-cred",
+				Namespace: "default",
+			}
+			err := d.buildAlternativesList(
+				ctx,
+				[]kuikv1alpha1.ImageSetMirror{cism},
+				nil,
+				c,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Images[0].CredentialSecret.Name).To(Equal("harbor-pull-cred"))
 		})
 	})
 })


### PR DESCRIPTION
This allows use of a separate secret for pulling, so the privileged one isn't copied to other Namespaces

Fixes #579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a dedicated image pull credential secret for mirrored images.
  * Pull credentials can be specified by name and namespace and are added to workloads when mirrored images are used.
  * Existing credentials remain the fallback when no dedicated pull credential is configured.

* **Documentation**
  * Updated CRD documentation and local registry configuration examples to describe the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->