### PR TITLE
ci(deps): group security updates and widen dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,3 +92,54 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+
+  # Maintenance branch: conservative patch-only updates as a proxy for
+  # security fixes, since alert-driven security updates only target the
+  # default branch. The "fix" commit prefix makes semantic-release cut a
+  # patch release on merge. Update target-branch when a new maintenance
+  # branch is cut (see website/README.md, "Add a new archived version").
+  - package-ecosystem: "gomod"
+    open-pull-requests-limit: 1
+    directory: "/"
+    target-branch: "2.3.x"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    open-pull-requests-limit: 1
+    directory: "/"
+    target-branch: "2.3.x"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+    groups:
+      patch:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,28 +7,88 @@ updates:
       interval: "monthly"
     groups:
       minor-and-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
   - package-ecosystem: "gomod"
-    # Security updates have a separate, internal limit of ten open pull requests
+    # Limit of 2 so that a pending kubernetes group PR does not block routine
+    # updates. Security updates have a separate, internal limit of ten open
+    # pull requests:
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 2
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "10:00"
       timezone: "Europe/Paris"
+    # Supply-chain protection: wait a few days before adopting fresh releases.
+    # Does not delay security updates.
+    cooldown:
+      default-days: 7
+    groups:
+      # Kubernetes libraries follow the controller-runtime / Kubernetes
+      # compatibility matrix, so their bumps get a dedicated PR to be reviewed
+      # on their own instead of riding along with routine updates
+      kubernetes:
+        applies-to: version-updates
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        update-types:
+          - "minor"
+          - "patch"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    open-pull-requests-limit: 1
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
     groups:
       minor-and-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
           - "minor"
           - "patch"
-    ignore:
-      - dependency-name: k8s.io/*
-        update-types: [version-update:semver-major, version-update:semver-minor]
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    open-pull-requests-limit: 1
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/website/README.md
+++ b/website/README.md
@@ -78,3 +78,5 @@ To publish version `X.Y` (e.g. when cutting a release):
    ```
 
 4. `npm run build` (with the branch fetched locally) — the link validator checks every version's pages. To update a published version later, commit the doc fix to its maintenance branch and redeploy; no re-tagging needed.
+
+5. Point the maintenance-branch Dependabot entries at the new branch: in [`.github/dependabot.yml`](../.github/dependabot.yml) (on `main`), update the `target-branch` of the patch-only `gomod` and `docker` entries to `X.Y.x` (and drop entries for release lines that reached end of life).


### PR DESCRIPTION
- Group security updates per ecosystem (they ignore open-pull-requests-limit and were opened as individual PRs)
- Drop the k8s.io ignore rule, which also silently blocked security updates; Kubernetes libraries now get a dedicated version-updates group so their bumps are reviewed on their own (gomod limit raised to 2 accordingly)
- Add a 7-day cooldown on gomod and npm as supply-chain protection
- Add the docker ecosystem to track base images
- Enable grouped monthly version updates for the website (npm)