### PR TITLE
docs: move the maintenance-branch procedure to CONTRIBUTING.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,7 +97,7 @@ updates:
   # security fixes, since alert-driven security updates only target the
   # default branch. The "fix" commit prefix makes semantic-release cut a
   # patch release on merge. Update target-branch when a new maintenance
-  # branch is cut (see website/README.md, "Add a new archived version").
+  # branch is cut (see CONTRIBUTING.md, "Cutting a maintenance branch").
   - package-ecosystem: "gomod"
     open-pull-requests-limit: 1
     directory: "/"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,18 @@ The following rules apply:
 ### License
 
 kube-image-keeper is licensed under the [MIT License](./LICENSE). By contributing to this project, you agree to license your contributions under the same license.
+
+## Cutting a maintenance branch
+
+Each release line `X.Y` is maintained from a **maintenance branch `X.Y.x`**: semantic-release publishes maintenance releases from it (see the `branches` glob in [`.releaserc.json`](./.releaserc.json)), and it carries both the release-line code and its published documentation. When cutting a new line `X.Y`:
+
+1. Create the branch from the release tag and push it:
+
+   ```bash
+   git switch -c X.Y.x vX.Y.Z
+   git push -u origin X.Y.x
+   ```
+
+2. Retarget the maintenance-branch Dependabot entries: in [`.github/dependabot.yml`](./.github/dependabot.yml) (on `main`), update the `target-branch` of the patch-only `gomod` and `docker` entries to `X.Y.x`, and drop entries for release lines that reached end of life. These entries keep the release line's dependencies patched (security fixes almost always ship as patch releases), and their `fix` commit prefix makes semantic-release cut a patch release when they are merged.
+
+3. Publish the version's documentation on the website: see [Add a new archived version](./website/README.md#add-a-new-archived-version).

--- a/website/README.md
+++ b/website/README.md
@@ -60,13 +60,9 @@ results".
 
 To publish version `X.Y` (e.g. when cutting a release):
 
-1. Create the version's **maintenance branch `X.Y.x`** from the release tag (this is the same branch that semantic-release publishes maintenance releases from — see the `branches` glob in [`.releaserc.json`](../.releaserc.json)):
+1. Create the version's **maintenance branch `X.Y.x`** and retarget the Dependabot maintenance entries, as described in [Cutting a maintenance branch](../CONTRIBUTING.md#cutting-a-maintenance-branch).
 
-   ```bash
-   git switch -c X.Y.x vX.Y.Z
-   ```
-
-2. In that branch's `docs/`, add a **`version-config.json`** with the Starlight sidebar for the version (slugs relative to the version, e.g. `"configuration"`, not `"X.Y/…"`). Leave the markdown as plain GitHub docs — **no `slug:` frontmatter** (the build injects it). Fix any links the validator later rejects (repo-root links like `/docs/crds.md#x` become relative `../crds.md#x`), then commit and `git push -u origin X.Y.x`.
+2. In that branch's `docs/`, add a **`version-config.json`** with the Starlight sidebar for the version (slugs relative to the version, e.g. `"configuration"`, not `"X.Y/…"`). Leave the markdown as plain GitHub docs — **no `slug:` frontmatter** (the build injects it). Fix any links the validator later rejects (repo-root links like `/docs/crds.md#x` become relative `../crds.md#x`), then commit and push.
 
 3. Register the version in [`versions.mjs`](./versions.mjs):
 
@@ -78,5 +74,3 @@ To publish version `X.Y` (e.g. when cutting a release):
    ```
 
 4. `npm run build` (with the branch fetched locally) — the link validator checks every version's pages. To update a published version later, commit the doc fix to its maintenance branch and redeploy; no re-tagging needed.
-
-5. Point the maintenance-branch Dependabot entries at the new branch: in [`.github/dependabot.yml`](../.github/dependabot.yml) (on `main`), update the `target-branch` of the patch-only `gomod` and `docker` entries to `X.Y.x` (and drop entries for release lines that reached end of life).


### PR DESCRIPTION
## What

Moves the release-ops steps of cutting a release line out of the website README into a dedicated ["Cutting a maintenance branch"](https://github.com/enix/kube-image-keeper/blob/docs/maintenance-branch-procedure/CONTRIBUTING.md#cutting-a-maintenance-branch) section in `CONTRIBUTING.md`:

- creating the `X.Y.x` branch from the release tag and pushing it
- retargeting the patch-only Dependabot entries (`gomod` and `docker`) to the new branch and dropping end-of-life ones

## Why

These steps are release operations, not documentation publishing; they only lived in the website README's "Add a new archived version" checklist because that was the one written procedure triggered by cutting a release line. The website checklist now focuses on the docs side and references the new section for its first step. The pointer comment in `.github/dependabot.yml` is updated accordingly.

No behaviour change; documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating maintenance branches, updating automated maintenance settings, and publishing archived documentation.
  * Updated archived-version publishing instructions to reflect the revised release process.
  * Clarified links to the relevant maintenance-branch documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->