### PR TITLE
fix(registry): do not retry rate-limited requests at the transport level

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -24,6 +24,20 @@ import (
 
 type descriptorReader func(ref name.Reference, options ...remote.Option) (*v1.Descriptor, error)
 
+// retryStatusCodes overrides go-containerregistry's defaults, which retry 429
+// since v0.21.9. Rate limits must surface immediately as QuotaExceeded so the
+// monitoring scheduler backs off instead of spending more of the quota on
+// transport-level retries.
+var retryStatusCodes = []int{
+	http.StatusRequestTimeout,
+	http.StatusInternalServerError,
+	http.StatusBadGateway,
+	http.StatusServiceUnavailable,
+	http.StatusGatewayTimeout,
+	499, // nginx-specific, client closed request
+	522, // Cloudflare-specific, connection timeout
+}
+
 type Client struct {
 	insecureRegistries []string
 	rootCAs            *x509.CertPool
@@ -98,6 +112,7 @@ func (c *Client) Execute(ctx context.Context, imageName string, action func(ref 
 
 			opts := []remote.Option{
 				remote.WithAuthFromKeychain(keychain),
+				remote.WithRetryStatusCodes(retryStatusCodes...),
 				transportOption,
 				contextOption,
 			}

--- a/internal/registry/retry_test.go
+++ b/internal/registry/retry_test.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// rateLimitedRegistry answers the /v2/ ping and returns 429 on every manifest
+// request, counting them.
+type rateLimitedRegistry struct {
+	manifestReads atomic.Int64
+}
+
+func (r *rateLimitedRegistry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == "/v2/" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if strings.Contains(req.URL.Path, "/manifests/") {
+		r.manifestReads.Add(1)
+		w.Header().Set("RateLimit-Remaining", "0;w=21600")
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+// A 429 must surface immediately: kuik reports it as QuotaExceeded and its
+// monitoring scheduler backs off, so transport-level retries would only spend
+// more of an exhausted quota. go-containerregistry retries 429 by default
+// since v0.21.9; this pins the pre-v0.21.9 behavior.
+func TestRateLimitedRequestIsNotRetried(t *testing.T) {
+	fake := &rateLimitedRegistry{}
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	reference := strings.TrimPrefix(server.URL, "http://") + "/test/image:latest"
+	client := NewClient([]string{strings.TrimPrefix(server.URL, "http://")}, nil)
+
+	_, headers, err := client.ReadDescriptor(context.Background(), http.MethodHead, reference)
+	if err == nil {
+		t.Fatal("expected an error from the rate-limited registry, got nil")
+	}
+	if code := TransportStatusCode(err); code != http.StatusTooManyRequests {
+		t.Errorf("transport status code = %d, want %d", code, http.StatusTooManyRequests)
+	}
+	if !IsRateLimited(headers) {
+		t.Error("expected rate-limit headers to be captured")
+	}
+	if reads := fake.manifestReads.Load(); reads != 1 {
+		t.Errorf("manifest read requests = %d, want 1 (429 must not be retried)", reads)
+	}
+}


### PR DESCRIPTION
go-containerregistry v0.21.9 (pulled in by the minor-and-patch dependabot group) added 429 to its default transport retry status codes. kuik already handles rate limits one level up: a 429 is reported as `QuotaExceeded` and the monitoring scheduler backs off, so transport-level retries only spend more of an already exhausted quota and delay the availability verdict by several seconds of backoff.

This pins the retry status codes to the pre-v0.21.9 list (transient 5xx plus 408, 499 and 522) and adds a regression test asserting that a rate-limited manifest request reaches the registry exactly once.

Unblocks #613, whose new rate-limit test is the first to catch this. The same regression exists on `2.3.x` (the security dependency bump brought v0.21.9 there too), so this needs a cherry-pick after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Registry requests receiving HTTP 429 rate-limit responses are no longer automatically retried.
  - Rate-limit response status and headers are preserved for clearer client handling.
  - Prevents repeated requests during rate limiting, reducing unnecessary load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->