### PR TITLE
fix(registry): backport digest-path availability check and 429 retry fix to 2.3.x

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -31,6 +31,12 @@ concurrency:
 
 jobs:
   build:
+    # The site always builds from main's website/ directory, which does not
+    # exist on maintenance branches (X.Y.x). A pull request targeting a
+    # maintenance branch therefore has nothing meaningful to validate here
+    # (and the build would fail on the missing directory), so only validate
+    # pushes and pull requests targeting main.
+    if: github.event_name == 'push' || github.base_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,8 +70,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this single envelope covers both the tag and digest requests sequentially; increase to at least `2s`–`3s` to give each request a fair share of the budget. |
-| `routing.activeCheck.resolveDigest` | bool | `false` | When `true` and the reference is a tag, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. References already by digest are not rechecked. Doubles the number of requests per tag admission. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled, the timeout applies to each of the two requests individually. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, tag references are checked a second time by manifest digest, catching registries that serve a tag whose manifest is gone. References already pinned to a digest are not rechecked. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -79,7 +79,7 @@ Controls the mutating webhook that rewrites Pod container images.
 
 Durations use Go's `time.ParseDuration` syntax (`"500ms"`, `"30s"`, `"2h"`, ...).
 
-### Examples
+### Example
 
 Lower the active-check timeout and keep `Always` containers in the standard priority sort:
 
@@ -88,22 +88,6 @@ routing:
   activeCheck:
     timeout: 500ms
   honorPrioritiesOnAlwaysImagePullPolicy: true
-```
-
-Enable digest-path verification and adjust rate limits to account for doubled requests:
-
-```yaml
-routing:
-  activeCheck:
-    resolveDigest: true
-    timeout: 3s  # increase from the 1s default — resolveDigest makes two sequential requests
-
-monitoring:
-  registries:
-    items:
-      docker.io:
-        interval: 1h
-        maxPerInterval: 3  # halved from 6 — resolveDigest doubles per-image request count
 ```
 
 ## `mirroring`
@@ -158,9 +142,9 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled each check makes two requests; halve this value for rate-constrained registries to avoid quota exhaustion. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each check makes two requests. |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
-| `resolveDigest` | bool | unset (disabled) | When `true`, a second request is made by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies. Doubles request quota. Set to `false` in an `items` override to disable for a specific registry that inherits a `true` default. |
+| `resolveDigest` | bool | unset (disabled) | Same digest check as `routing.activeCheck.resolveDigest`, applied to monitoring probes. An `items` entry leaving it unset inherits the `default` value; setting it to `false` opts that registry out. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |
 
 ### Default for `monitoring.registries.items`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,7 @@ The following file shows every supported key with its default value. You only ne
 routing:
   activeCheck:
     timeout: 1s
+    resolveDigest: false
     staleMirrorCleanup:
       maxConcurrent: 10
       timeout: 5s
@@ -42,6 +43,7 @@ monitoring:
       method: HEAD
       interval: 3h
       maxPerInterval: 25
+      resolveDigest: false
       # timeout: 0          (no per-check timeout)
       # fallbackCredentialSecret:
       #   namespace: ...
@@ -142,7 +144,7 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each check makes two requests. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each tag-reference check makes two requests (digest references still make one). |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
 | `resolveDigest` | bool | unset (disabled) | Same digest check as `routing.activeCheck.resolveDigest`, applied to monitoring probes. An `items` entry leaving it unset inherits the `default` value; setting it to `false` opts that registry out. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this envelope covers both requests. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. Doubles the number of requests per admission. |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -142,8 +143,9 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled each check makes two requests; halve this value for rate-constrained registries to avoid quota exhaustion. |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
+| `resolveDigest` | bool | unset (disabled) | When `true`, a second request is made by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies. Doubles request quota. Set to `false` in an `items` override to disable for a specific registry that inherits a `true` default. |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |
 
 ### Default for `monitoring.registries.items`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,8 +70,8 @@ Controls the mutating webhook that rewrites Pod container images.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this envelope covers both requests. |
-| `routing.activeCheck.resolveDigest` | bool | `false` | When `true`, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. Doubles the number of requests per admission. |
+| `routing.activeCheck.timeout` | duration | `1s` | Per-image upper bound on the availability HTTP probe (HEAD request) made by the webhook before falling back to the next alternative. When `resolveDigest` is enabled this single envelope covers both the tag and digest requests sequentially; increase to at least `2s`–`3s` to give each request a fair share of the budget. |
+| `routing.activeCheck.resolveDigest` | bool | `false` | When `true` and the reference is a tag, the webhook active-check makes a second request by manifest digest after resolving the tag, detecting stale tag caches on pull-through proxies that advertise a tag but 404 on its digest. References already by digest are not rechecked. Doubles the number of requests per tag admission. |
 | `routing.activeCheck.staleMirrorCleanup.maxConcurrent` | int | `10` | Maximum number of concurrent goroutines clearing stale mirror status entries. The cleanup is dropped (not retried inline) if the semaphore is full; the next availability check that returns `NotFound` will trigger it again. |
 | `routing.activeCheck.staleMirrorCleanup.timeout` | duration | `5s` | Per-cleanup deadline for the goroutine that clears a stale mirror status entry. |
 | `routing.rewriteOnNeverImagePullPolicy` | bool | `false` | When `false`, containers with `imagePullPolicy: Never` are left untouched (the cluster-local image is assumed authoritative). Set to `true` to rewrite them as well. |
@@ -79,16 +79,31 @@ Controls the mutating webhook that rewrites Pod container images.
 
 Durations use Go's `time.ParseDuration` syntax (`"500ms"`, `"30s"`, `"2h"`, ...).
 
-### Example
+### Examples
 
-Lower the active-check timeout, keep `Always` containers in the standard
-priority sort:
+Lower the active-check timeout and keep `Always` containers in the standard priority sort:
 
 ```yaml
 routing:
   activeCheck:
     timeout: 500ms
   honorPrioritiesOnAlwaysImagePullPolicy: true
+```
+
+Enable digest-path verification and adjust rate limits to account for doubled requests:
+
+```yaml
+routing:
+  activeCheck:
+    resolveDigest: true
+    timeout: 3s  # increase from the 1s default — resolveDigest makes two sequential requests
+
+monitoring:
+  registries:
+    items:
+      docker.io:
+        interval: 1h
+        maxPerInterval: 3  # halved from 6 — resolveDigest doubles per-image request count
 ```
 
 ## `mirroring`

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -11,10 +11,10 @@ By default, the availability check does what a plain `docker pull` of a tag star
 
 In both cases the tag request returns `200`, kuik marks the image `Available`, and the pull fails anyway. Setting `resolveDigest: true` makes kuik follow the same two-step path as the runtime. A `404` on the digest request is reported as `NotFound` with a `tag/digest inconsistency` message, which triggers the usual fallback to the next alternative and the re-mirror path.
 
-The check is opt-in because it **doubles the number of registry requests** for every checked tag. Two things must be kept in mind when enabling it:
+The check is opt-in because it **doubles the number of registry requests** for every checked tag reference (references already pinned to a digest still cost a single request). Two things must be kept in mind when enabling it:
 
-- **`routing.activeCheck.timeout`** — the timeout applies to each request individually, so a check can take up to `2 × timeout` of wall time before the webhook falls back to the next alternative. Lower it if admission latency matters more than probe reliability.
-- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
+- **`routing.activeCheck.timeout`** — the timeout applies to each request individually, so a tag check can take up to `2 × timeout` of wall time before the webhook falls back to the next alternative. Lower it if admission latency matters more than probe reliability.
+- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each tag-referenced image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
 
 ```yaml
 routing:
@@ -27,13 +27,13 @@ monitoring:
       docker.io:
         resolveDigest: true
         interval: 1h
-        maxPerInterval: 3 # halved from 6, each check now costs two requests
+        maxPerInterval: 3 # halved from 6, each tag check now costs two requests
 ```
 
 `routing.activeCheck.resolveDigest` (webhook) and `monitoring.registries.*.resolveDigest` (`ClusterImageSetAvailability` probes) are independent, enable whichever surface you need. The per-registry value is a three-state boolean: unset inherits `monitoring.registries.default`, `false` opts a single registry out of an enabled default.
 
 > [!NOTE]
-> Registries that answer `405` or `501` to a manifest-by-digest request are treated as available. They support tag lookup but not the digest path for that HTTP method, and serve the image fine to container runtimes.
+> Registries that answer `405` or `501` to a **HEAD** manifest-by-digest request are treated as available: HEAD support on the digest path is optional for proxies, and they still serve the image fine to container runtimes. The same answer to a **GET** probe is reported as unreachable, since runtimes pull with GET.
 
 ## Duplicated credential secrets (`kuik-kuik-...`)
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,5 +1,40 @@
 # Troubleshooting
 
+## Stale tag caches on pull-through proxies
+
+**Symptom:** kuik reports an image as available (and keeps routing pods to it), but pods pulling it fail with `manifest unknown` or `not found` on every node that does not already have the image in its local store.
+
+By default, the availability check does what a plain `docker pull` of a tag starts with: one `HEAD` (or `GET`) on the tag. Container runtimes do more, they resolve the tag to a manifest digest, then fetch the manifest *by that digest*. Some registries answer the two requests inconsistently:
+
+- a pull-through proxy whose upstream image was deleted or garbage-collected keeps serving the cached tag while the manifest behind it is gone;
+- a scanner-gated registry (Artifactory with Xray, for instance) can block a specific manifest by digest while the tag lookup still succeeds.
+
+In both cases the tag request returns `200`, kuik marks the image `Available`, and the pull fails anyway. Setting `resolveDigest: true` makes kuik follow the same two-step path as the runtime. A `404` on the digest request is reported as `NotFound` with a `tag/digest inconsistency` message, which triggers the usual fallback to the next alternative and the re-mirror path.
+
+The check is opt-in because it **doubles the number of registry requests** for every checked tag. Two things must be kept in mind when enabling it:
+
+- **`routing.activeCheck.timeout`** — the timeout applies to each request individually, so a check can take up to `2 × timeout` of wall time before the webhook falls back to the next alternative. Lower it if admission latency matters more than probe reliability.
+- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
+
+```yaml
+routing:
+  activeCheck:
+    resolveDigest: true # each of the two requests gets the full activeCheck timeout
+
+monitoring:
+  registries:
+    items:
+      docker.io:
+        resolveDigest: true
+        interval: 1h
+        maxPerInterval: 3 # halved from 6, each check now costs two requests
+```
+
+`routing.activeCheck.resolveDigest` (webhook) and `monitoring.registries.*.resolveDigest` (`ClusterImageSetAvailability` probes) are independent, enable whichever surface you need. The per-registry value is a three-state boolean: unset inherits `monitoring.registries.default`, `false` opts a single registry out of an enabled default.
+
+> [!NOTE]
+> Registries that answer `405` or `501` to a manifest-by-digest request are treated as available. They support tag lookup but not the digest path for that HTTP method, and serve the image fine to container runtimes.
+
 ## Duplicated credential secrets (`kuik-kuik-...`)
 
 When a `(Cluster)ImageSetMirror` or `(Cluster)ReplicatedImageSet` declares a `credentialSecret`, kuik copies it into every namespace where a matching image is rerouted, naming the copy `kuik-<secret-name>-<hash>`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Routing struct {
 
 type ActiveCheck struct {
 	Timeout            time.Duration      `koanf:"timeout"`
+	ResolveDigest      bool               `koanf:"resolveDigest"`
 	StaleMirrorCleanup StaleMirrorCleanup `koanf:"staleMirrorCleanup"`
 }
 
@@ -62,7 +63,14 @@ type RegistryMonitoring struct {
 	Interval                 time.Duration                  `koanf:"interval"`
 	MaxPerInterval           int                            `koanf:"maxPerInterval"`
 	Timeout                  time.Duration                  `koanf:"timeout"`
+	ResolveDigest            *bool                          `koanf:"resolveDigest"`
 	FallbackCredentialSecret *kuikv1alpha1.CredentialSecret `koanf:"fallbackCredentialSecret"`
+}
+
+// ResolveDigestEnabled returns true when the digest-path check is enabled for
+// this registry. A nil ResolveDigest means unset (inherit / disabled).
+func (r *RegistryMonitoring) ResolveDigestEnabled() bool {
+	return r.ResolveDigest != nil && *r.ResolveDigest
 }
 
 type Metrics struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,8 +67,10 @@ type RegistryMonitoring struct {
 	FallbackCredentialSecret *kuikv1alpha1.CredentialSecret `koanf:"fallbackCredentialSecret"`
 }
 
-// ResolveDigestEnabled returns true when the digest-path check is enabled for
-// this registry. A nil ResolveDigest means unset (inherit / disabled).
+// ResolveDigestEnabled returns true when the digest-path check is explicitly
+// enabled for this registry. The three states are: nil = inherit from default
+// (treated as disabled until overridden), *false = explicitly disabled (overrides
+// an enabled default for this specific registry), *true = enabled.
 func (r *RegistryMonitoring) ResolveDigestEnabled() bool {
 	return r.ResolveDigest != nil && *r.ResolveDigest
 }

--- a/internal/controller/kuik/clusterimagesetavailability_controller.go
+++ b/internal/controller/kuik/clusterimagesetavailability_controller.go
@@ -187,6 +187,9 @@ func (r *ClusterImageSetAvailabilityReconciler) registryConfig(registry string) 
 		if override.Timeout != 0 {
 			merged.Timeout = override.Timeout
 		}
+		if override.ResolveDigest != nil {
+			merged.ResolveDigest = override.ResolveDigest
+		}
 		if override.FallbackCredentialSecret != nil {
 			merged.FallbackCredentialSecret = override.FallbackCredentialSecret
 		}
@@ -320,7 +323,7 @@ func (r *ClusterImageSetAvailabilityReconciler) performCheck(ctx context.Context
 		image.LastError = err.Error()
 	}
 
-	result, checkErr := registry.CheckImageAvailability(ctx, image.Image, registryConfig.Method, registryConfig.Timeout, pullSecrets)
+	result, checkErr := registry.CheckImageAvailability(ctx, image.Image, registryConfig.Method, registryConfig.Timeout, pullSecrets, registryConfig.ResolveDigestEnabled())
 	image.LastMonitor = &now
 
 	if image.Status == kuikv1alpha1.ImageAvailabilityUnavailableSecret && result == kuikv1alpha1.ImageAvailabilityInvalidAuth {

--- a/internal/controller/kuik/registryconfig_test.go
+++ b/internal/controller/kuik/registryconfig_test.go
@@ -1,0 +1,88 @@
+package kuik
+
+import (
+	"testing"
+	"time"
+
+	"github.com/enix/kube-image-keeper/internal/config"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// The per-registry resolveDigest override is a three-state boolean: an items
+// entry leaving it unset (nil) inherits the default, an explicit false opts a
+// single registry out of an enabled default, an explicit true opts it in.
+func TestRegistryConfigResolveDigest(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultFlag *bool
+		override    *config.RegistryMonitoring
+		want        bool
+	}{
+		{
+			name: "no override, unset default is disabled",
+		},
+		{
+			name:        "no override inherits enabled default",
+			defaultFlag: boolPtr(true),
+			want:        true,
+		},
+		{
+			name:        "unset override inherits enabled default",
+			defaultFlag: boolPtr(true),
+			override:    &config.RegistryMonitoring{},
+			want:        true,
+		},
+		{
+			name:        "explicit false overrides enabled default",
+			defaultFlag: boolPtr(true),
+			override:    &config.RegistryMonitoring{ResolveDigest: boolPtr(false)},
+			want:        false,
+		},
+		{
+			name:     "explicit true overrides unset default",
+			override: &config.RegistryMonitoring{ResolveDigest: boolPtr(true)},
+			want:     true,
+		},
+		{
+			name:        "explicit true overrides disabled default",
+			defaultFlag: boolPtr(false),
+			override:    &config.RegistryMonitoring{ResolveDigest: boolPtr(true)},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registries := config.Registries{
+				Default: config.RegistryMonitoring{
+					Method:         "HEAD",
+					Interval:       3 * time.Hour,
+					MaxPerInterval: 25,
+					ResolveDigest:  tt.defaultFlag,
+				},
+				Items: map[string]config.RegistryMonitoring{},
+			}
+			if tt.override != nil {
+				registries.Items["registry.example.com"] = *tt.override
+			}
+
+			r := &ClusterImageSetAvailabilityReconciler{
+				Config: &config.Config{
+					Monitoring: config.Monitoring{Registries: registries},
+				},
+			}
+
+			merged := r.registryConfig("registry.example.com")
+			if got := merged.ResolveDigestEnabled(); got != tt.want {
+				t.Errorf("ResolveDigestEnabled() = %v, want %v (default=%v, override=%+v)", got, tt.want, tt.defaultFlag, tt.override)
+			}
+
+			// The merge must not clobber unrelated defaults when the override
+			// only sets resolveDigest.
+			if merged.Method != "HEAD" || merged.MaxPerInterval != 25 {
+				t.Errorf("merge clobbered unrelated defaults: %+v", merged)
+			}
+		})
+	}
+}

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -14,26 +16,88 @@ import (
 // and returns the availability status of the image along with any error encountered.
 // The error is non-nil for all non-Available statuses and contains the underlying
 // cause (e.g. HTTP status text, transport error).
-func CheckImageAvailability(ctx context.Context, reference string, method string, timeout time.Duration, pullSecrets []corev1.Secret) (kuikv1alpha1.ImageAvailabilityStatus, error) {
-	_, headers, err := NewClient(nil, nil).
+//
+// When resolveDigest is true and the reference is a tag, a second request (using
+// the same HTTP method) is made for the manifest digest the registry advertised
+// for that tag. This emulates the pull path of container runtimes (resolve tag
+// to digest, then fetch the manifest by digest) and catches registries that keep
+// answering tag requests while the manifest behind the digest is gone (typically
+// pull-through proxies with a stale tag cache): on such registries, tag HEAD/GET
+// return 200 but every node that does not already have the image in its local
+// store fails to pull.
+//
+// Note: when resolveDigest is true the check makes two requests, which doubles
+// rate-limit quota consumption for that image. Halve monitoring.registries.*.maxPerInterval
+// for rate-constrained registries (e.g. docker.io) when enabling this flag.
+// The timeout applies to each request individually, so the total wall time is
+// bounded by 2 × timeout when resolveDigest is enabled.
+func CheckImageAvailability(ctx context.Context, reference string, method string, timeout time.Duration, pullSecrets []corev1.Secret, resolveDigest bool) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	client := NewClient(nil, nil).
 		WithTimeout(timeout).
-		WithPullSecrets(pullSecrets).
-		ReadDescriptor(method, reference)
+		WithPullSecrets(pullSecrets)
+
+	desc, headers, err := client.ReadDescriptor(method, reference)
 
 	if IsRateLimited(headers) {
 		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded")
 	}
 
 	if err != nil {
-		switch TransportStatusCode(err) {
-		case http.StatusNotFound:
-			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
-		case http.StatusUnauthorized, http.StatusForbidden:
-			return kuikv1alpha1.ImageAvailabilityInvalidAuth, fmt.Errorf("authentication failed: %w", err)
-		default:
-			return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("registry unreachable: %w", err)
-		}
+		return availabilityFromError(err)
+	}
+
+	if resolveDigest {
+		return checkDigestPath(client, method, reference, desc)
 	}
 
 	return kuikv1alpha1.ImageAvailabilityAvailable, nil
+}
+
+// checkDigestPath verifies that the manifest digest advertised for a reference
+// can actually be fetched by digest. References that are already digest-addressed
+// are not checked again: the initial request covered the exact manifest the
+// runtime will pull.
+//
+// The same HTTP method used for the tag request is used for the digest request so
+// that registries requiring GET for manifest-by-digest are handled correctly.
+func checkDigestPath(client *Client, method string, reference string, desc *v1.Descriptor) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	ref, err := name.ParseReference(reference)
+	if err != nil {
+		// the initial request already succeeded for this reference, so this
+		// should never happen; report it rather than failing open
+		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("could not parse reference: %w", err)
+	}
+
+	if _, isDigest := ref.(name.Digest); isDigest || desc == nil {
+		return kuikv1alpha1.ImageAvailabilityAvailable, nil
+	}
+
+	digestReference := ref.Context().Name() + "@" + desc.Digest.String()
+	_, headers, err := client.ReadDescriptor(method, digestReference)
+
+	if IsRateLimited(headers) {
+		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded")
+	}
+
+	if err != nil {
+		if TransportStatusCode(err) == http.StatusNotFound {
+			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+		}
+		return availabilityFromError(err)
+	}
+
+	return kuikv1alpha1.ImageAvailabilityAvailable, nil
+}
+
+// availabilityFromError maps a registry transport error to an availability
+// status, wrapping the underlying cause.
+func availabilityFromError(err error) (kuikv1alpha1.ImageAvailabilityStatus, error) {
+	switch TransportStatusCode(err) {
+	case http.StatusNotFound:
+		return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return kuikv1alpha1.ImageAvailabilityInvalidAuth, fmt.Errorf("authentication failed: %w", err)
+	default:
+		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("registry unreachable: %w", err)
+	}
 }

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -86,7 +86,7 @@ func checkDigestPath(client *Client, method string, reference string, desc *v1.D
 	if err != nil {
 		switch TransportStatusCode(err) {
 		case http.StatusNotFound:
-			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest: %w", reference, desc.Digest.String(), err)
 		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
 			// The registry supports tag lookup but not manifest-by-digest for this
 			// HTTP method; the tag check already passed so the image is pullable.

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -68,6 +68,10 @@ func checkDigestPath(client *Client, method string, reference string, desc *v1.D
 		return kuikv1alpha1.ImageAvailabilityUnreachable, fmt.Errorf("could not parse reference: %w", err)
 	}
 
+	// Digest-addressed refs already targeted the exact manifest the runtime will
+	// pull, so no second request is needed. desc == nil is a defensive fallback:
+	// ReadDescriptor returned no error but no descriptor; skip digest verification
+	// and treat the image as available rather than failing open on a nil dereference.
 	if _, isDigest := ref.(name.Digest); isDigest || desc == nil {
 		return kuikv1alpha1.ImageAvailabilityAvailable, nil
 	}
@@ -80,8 +84,13 @@ func checkDigestPath(client *Client, method string, reference string, desc *v1.D
 	}
 
 	if err != nil {
-		if TransportStatusCode(err) == http.StatusNotFound {
+		switch TransportStatusCode(err) {
+		case http.StatusNotFound:
 			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest by digest, pulls from this registry will fail on any node that does not already have the image: %w", reference, desc.Digest.String(), err)
+		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
+			// The registry supports tag lookup but not manifest-by-digest for this
+			// HTTP method; the tag check already passed so the image is pullable.
+			return kuikv1alpha1.ImageAvailabilityAvailable, nil
 		}
 		return availabilityFromError(err)
 	}

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -88,9 +88,14 @@ func checkDigestPath(client *Client, method string, reference string, desc *v1.D
 		case http.StatusNotFound:
 			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest: %w", reference, desc.Digest.String(), err)
 		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
-			// The registry supports tag lookup but not manifest-by-digest for this
-			// HTTP method; the tag check already passed so the image is pullable.
-			return kuikv1alpha1.ImageAvailabilityAvailable, nil
+			// Some proxies support tag lookup but not manifest-by-digest over
+			// HEAD, while still serving GET-by-digest fine to container runtimes
+			// (HEAD support is optional in the distribution spec). Only give the
+			// benefit of the doubt to HEAD probes: runtimes pull with GET, so a
+			// registry rejecting GET-by-digest cannot serve the image.
+			if method == http.MethodHead {
+				return kuikv1alpha1.ImageAvailabilityAvailable, nil
+			}
 		}
 		return availabilityFromError(err)
 	}
@@ -102,6 +107,11 @@ func checkDigestPath(client *Client, method string, reference string, desc *v1.D
 // status, wrapping the underlying cause.
 func availabilityFromError(err error) (kuikv1alpha1.ImageAvailabilityStatus, error) {
 	switch TransportStatusCode(err) {
+	case http.StatusTooManyRequests:
+		// Some registries send 429 without RateLimit-* headers, so IsRateLimited
+		// does not catch them; the status code alone must map to QuotaExceeded
+		// for the monitoring scheduler to apply its back-off.
+		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded: %w", err)
 	case http.StatusNotFound:
 		return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
 	case http.StatusUnauthorized, http.StatusForbidden:

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -16,26 +16,49 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
-// brokenDigestRegistry wraps an in-memory registry and can be set to return
-// 404 for manifest requests by digest while keeping tag requests working.
-// This reproduces a pull-through proxy with a stale tag cache: tags keep
-// resolving (HEAD and GET return 200 with a Docker-Content-Digest header),
-// but the manifests behind those digests are gone, so container runtimes
-// fail to pull on any node that does not already have the image.
+// digestResponseMode controls how brokenDigestRegistry responds to manifest-by-digest requests.
+type digestResponseMode int
+
+const (
+	digestResponseNormal           digestResponseMode = iota // pass through to the real registry
+	digestResponseNotFound                                   // 404 — stale tag cache / blocked by policy
+	digestResponseRateLimit                                  // 429 with RateLimit-Remaining: 0 header
+	digestResponseUnauthorized                               // 401 — fine-grained auth on digest path
+	digestResponseMethodNotAllowed                           // 405 — proxy supports tags but not digest lookup
+)
+
+// brokenDigestRegistry wraps an in-memory registry and can intercept manifest-by-digest
+// requests to simulate various proxy and registry failure modes while keeping tag requests
+// working. Subtests must not run in parallel because digestMode is shared state.
 type brokenDigestRegistry struct {
 	handler       http.Handler
-	brokenDigests atomic.Bool
+	digestMode    atomic.Int32 // stores digestResponseMode
 	manifestReads atomic.Int64
 }
 
 func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.Contains(r.URL.Path, "/manifests/") && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
 		b.manifestReads.Add(1)
-		if b.brokenDigests.Load() && strings.Contains(r.URL.Path, "/manifests/sha256:") {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
-			return
+		if strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			switch digestResponseMode(b.digestMode.Load()) {
+			case digestResponseNotFound:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
+				return
+			case digestResponseRateLimit:
+				w.Header().Set("RateLimit-Remaining", "0;w=21600")
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			case digestResponseUnauthorized:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = fmt.Fprint(w, `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}`)
+				return
+			case digestResponseMethodNotAllowed:
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
 		}
 	}
 	b.handler.ServeHTTP(w, r)
@@ -66,7 +89,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 		name          string
 		reference     string
 		method        string
-		brokenDigests bool
+		digestMode    digestResponseMode
 		resolveDigest bool
 		want          kuikv1alpha1.ImageAvailabilityStatus
 		wantErr       string
@@ -96,18 +119,18 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			wantReads:     2,
 		},
 		{
-			name:          "broken digests without digest resolution stay invisible",
-			reference:     tagReference,
-			method:        http.MethodHead,
-			brokenDigests: true,
-			want:          kuikv1alpha1.ImageAvailabilityAvailable,
-			wantReads:     1,
+			name:       "broken digests without digest resolution stay invisible",
+			reference:  tagReference,
+			method:     http.MethodHead,
+			digestMode: digestResponseNotFound,
+			want:       kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:  1,
 		},
 		{
 			name:          "broken digests with digest resolution HEAD are detected",
 			reference:     tagReference,
 			method:        http.MethodHead,
-			brokenDigests: true,
+			digestMode:    digestResponseNotFound,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityNotFound,
 			wantErr:       "tag/digest inconsistency",
@@ -117,7 +140,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			name:          "broken digests with digest resolution GET are detected",
 			reference:     tagReference,
 			method:        http.MethodGet,
-			brokenDigests: true,
+			digestMode:    digestResponseNotFound,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityNotFound,
 			wantErr:       "tag/digest inconsistency",
@@ -131,11 +154,40 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			want:          kuikv1alpha1.ImageAvailabilityAvailable,
 			wantReads:     1,
 		},
+		{
+			name:          "rate limit on digest path returns QuotaExceeded",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseRateLimit,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityQuotaExceeded,
+			wantErr:       "rate limit exceeded",
+			wantReads:     2,
+		},
+		{
+			name:          "auth failure on digest path returns InvalidAuth",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseUnauthorized,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityInvalidAuth,
+			wantErr:       "authentication failed",
+			wantReads:     2,
+		},
+		{
+			name:          "digest method not allowed returns Available",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseMethodNotAllowed,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fake.brokenDigests.Store(tt.brokenDigests)
+			fake.digestMode.Store(int32(tt.digestMode))
 			readsBefore := fake.manifestReads.Load()
 
 			method := tt.method
@@ -157,7 +209,7 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 				}
 			}
 			if reads := fake.manifestReads.Load() - readsBefore; reads != tt.wantReads {
-				t.Errorf("manifest read requests = %d, want %d", reads, tt.wantReads)
+				t.Errorf("manifest read requests = %d, want %d (ref=%s method=%s resolveDigest=%v)", reads, tt.wantReads, tt.reference, tt.method, tt.resolveDigest)
 			}
 		})
 	}

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -1,0 +1,164 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	kuikv1alpha1 "github.com/enix/kube-image-keeper/api/kuik/v1alpha1"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+// brokenDigestRegistry wraps an in-memory registry and can be set to return
+// 404 for manifest requests by digest while keeping tag requests working.
+// This reproduces a pull-through proxy with a stale tag cache: tags keep
+// resolving (HEAD and GET return 200 with a Docker-Content-Digest header),
+// but the manifests behind those digests are gone, so container runtimes
+// fail to pull on any node that does not already have the image.
+type brokenDigestRegistry struct {
+	handler       http.Handler
+	brokenDigests atomic.Bool
+	manifestReads atomic.Int64
+}
+
+func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.URL.Path, "/manifests/") && (r.Method == http.MethodGet || r.Method == http.MethodHead) {
+		b.manifestReads.Add(1)
+		if b.brokenDigests.Load() && strings.Contains(r.URL.Path, "/manifests/sha256:") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = fmt.Fprint(w, `{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}`)
+			return
+		}
+	}
+	b.handler.ServeHTTP(w, r)
+}
+
+func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
+	fake := &brokenDigestRegistry{handler: registry.New()}
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	tagReference := host + "/test/image:latest"
+
+	image, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := crane.Push(image, tagReference); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := image.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestReference := host + "/test/image@" + digest.String()
+
+	tests := []struct {
+		name          string
+		reference     string
+		method        string
+		brokenDigests bool
+		resolveDigest bool
+		want          kuikv1alpha1.ImageAvailabilityStatus
+		wantErr       string
+		wantReads     int64
+	}{
+		{
+			name:      "healthy registry without digest resolution",
+			reference: tagReference,
+			method:    http.MethodHead,
+			want:      kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads: 1,
+		},
+		{
+			name:          "healthy registry with digest resolution HEAD",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "healthy registry with digest resolution GET",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "broken digests without digest resolution stay invisible",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			brokenDigests: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     1,
+		},
+		{
+			name:          "broken digests with digest resolution HEAD are detected",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			brokenDigests: true,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityNotFound,
+			wantErr:       "tag/digest inconsistency",
+			wantReads:     2,
+		},
+		{
+			name:          "broken digests with digest resolution GET are detected",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			brokenDigests: true,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityNotFound,
+			wantErr:       "tag/digest inconsistency",
+			wantReads:     2,
+		},
+		{
+			name:          "digest reference is not checked twice",
+			reference:     digestReference,
+			method:        http.MethodHead,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake.brokenDigests.Store(tt.brokenDigests)
+			readsBefore := fake.manifestReads.Load()
+
+			method := tt.method
+			if method == "" {
+				method = http.MethodHead
+			}
+			got, err := CheckImageAvailability(context.Background(), tt.reference, method, 5*time.Second, nil, tt.resolveDigest)
+
+			if got != tt.want {
+				t.Errorf("status = %v, want %v (err: %v)", got, tt.want, err)
+			}
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+			}
+			if reads := fake.manifestReads.Load() - readsBefore; reads != tt.wantReads {
+				t.Errorf("manifest read requests = %d, want %d", reads, tt.wantReads)
+			}
+		})
+	}
+}

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -20,11 +20,12 @@ import (
 type digestResponseMode int
 
 const (
-	digestResponseNormal           digestResponseMode = iota // pass through to the real registry
-	digestResponseNotFound                                   // 404 — stale tag cache / blocked by policy
-	digestResponseRateLimit                                  // 429 with RateLimit-Remaining: 0 header
-	digestResponseUnauthorized                               // 401 — fine-grained auth on digest path
-	digestResponseMethodNotAllowed                           // 405 — proxy supports tags but not digest lookup
+	digestResponseNormal             digestResponseMode = iota // pass through to the real registry
+	digestResponseNotFound                                     // 404 — stale tag cache / blocked by policy
+	digestResponseRateLimit                                    // 429 with RateLimit-Remaining: 0 header
+	digestResponseUnauthorized                                 // 401 — fine-grained auth on digest path
+	digestResponseMethodNotAllowed                             // 405 — proxy supports tags but not digest lookup
+	digestResponseRateLimitNoHeaders                           // 429 without RateLimit-* headers
 )
 
 // brokenDigestRegistry wraps an in-memory registry and can intercept manifest-by-digest
@@ -57,6 +58,9 @@ func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				return
 			case digestResponseMethodNotAllowed:
 				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			case digestResponseRateLimitNoHeaders:
+				w.WriteHeader(http.StatusTooManyRequests)
 				return
 			}
 		}
@@ -175,12 +179,32 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			wantReads:     2,
 		},
 		{
-			name:          "digest method not allowed returns Available",
+			name:          "digest method not allowed over HEAD returns Available",
 			reference:     tagReference,
 			method:        http.MethodHead,
 			digestMode:    digestResponseMethodNotAllowed,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "digest method not allowed over GET is not pullable",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			digestMode:    digestResponseMethodNotAllowed,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityUnreachable,
+			wantErr:       "registry unreachable",
+			wantReads:     2,
+		},
+		{
+			name:          "headerless rate limit on digest path returns QuotaExceeded",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseRateLimitNoHeaders,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityQuotaExceeded,
+			wantErr:       "rate limit exceeded",
 			wantReads:     2,
 		},
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -24,6 +24,20 @@ import (
 
 type descriptorReader func(ref name.Reference, options ...remote.Option) (*v1.Descriptor, error)
 
+// retryStatusCodes overrides go-containerregistry's defaults, which retry 429
+// since v0.21.9. Rate limits must surface immediately as QuotaExceeded so the
+// monitoring scheduler backs off instead of spending more of the quota on
+// transport-level retries.
+var retryStatusCodes = []int{
+	http.StatusRequestTimeout,
+	http.StatusInternalServerError,
+	http.StatusBadGateway,
+	http.StatusServiceUnavailable,
+	http.StatusGatewayTimeout,
+	499, // nginx-specific, client closed request
+	522, // Cloudflare-specific, connection timeout
+}
+
 type Client struct {
 	insecureRegistries []string
 	rootCAs            *x509.CertPool
@@ -99,6 +113,7 @@ func (c *Client) Execute(imageName string, action func(ref name.Reference, opts 
 
 			opts := []remote.Option{
 				remote.WithAuthFromKeychain(keychain),
+				remote.WithRetryStatusCodes(retryStatusCodes...),
 				transportOption,
 				contextOption,
 			}

--- a/internal/registry/retry_test.go
+++ b/internal/registry/retry_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// rateLimitedRegistry answers the /v2/ ping and returns 429 on every manifest
+// request, counting them.
+type rateLimitedRegistry struct {
+	manifestReads atomic.Int64
+}
+
+func (r *rateLimitedRegistry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == "/v2/" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if strings.Contains(req.URL.Path, "/manifests/") {
+		r.manifestReads.Add(1)
+		w.Header().Set("RateLimit-Remaining", "0;w=21600")
+		w.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+	w.WriteHeader(http.StatusNotFound)
+}
+
+// A 429 must surface immediately: kuik reports it as QuotaExceeded and its
+// monitoring scheduler backs off, so transport-level retries would only spend
+// more of an exhausted quota. go-containerregistry retries 429 by default
+// since v0.21.9; this pins the pre-v0.21.9 behavior.
+func TestRateLimitedRequestIsNotRetried(t *testing.T) {
+	fake := &rateLimitedRegistry{}
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	reference := strings.TrimPrefix(server.URL, "http://") + "/test/image:latest"
+	client := NewClient([]string{strings.TrimPrefix(server.URL, "http://")}, nil)
+
+	_, headers, err := client.ReadDescriptor(http.MethodHead, reference)
+	if err == nil {
+		t.Fatal("expected an error from the rate-limited registry, got nil")
+	}
+	if code := TransportStatusCode(err); code != http.StatusTooManyRequests {
+		t.Errorf("transport status code = %d, want %d", code, http.StatusTooManyRequests)
+	}
+	if !IsRateLimited(headers) {
+		t.Error("expected rate-limit headers to be captured")
+	}
+	if reads := fake.manifestReads.Load(); reads != 1 {
+		t.Errorf("manifest read requests = %d, want 1 (429 must not be retried)", reads)
+	}
+}

--- a/internal/webhook/core/v1/pod_webhook.go
+++ b/internal/webhook/core/v1/pod_webhook.go
@@ -530,7 +530,7 @@ func (d *PodCustomDefaulter) checkImageAvailabilityCached(ctx context.Context, i
 	err, _ := d.requestGroup.Do("availability:"+image.Reference, func() (any, error) {
 		log := logf.FromContext(ctx, "reference", image.Reference)
 
-		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets)
+		result, err := registry.CheckImageAvailability(ctx, image.Reference, http.MethodHead, d.Config.Routing.ActiveCheck.Timeout, pullSecrets, d.Config.Routing.ActiveCheck.ResolveDigest)
 		if err != nil {
 			log.V(1).Info("image is not available", "error", err)
 		} else {


### PR DESCRIPTION
Backport of #650 and #613 for the v2 release (fixes #626 on the maintenance line).

Adapted to the pre-context client API on this branch:

- the availability check's two requests each get their own timeout (worst case 2 × timeout) instead of sharing a single context envelope as on main;
- the troubleshooting guide and configuration reference are adjusted accordingly (no need to raise `routing.activeCheck.timeout` on this line);
- the errcheck fix on the test registry handler is folded into the commit that introduces the handler so every commit passes the hooks.

Also includes a CI fix uncovered by this PR: the website workflow tried to build `website/` (a main-only directory) on pull requests targeting maintenance branches; it now skips the build in that case (pushes are unaffected). The same fix will be applied to main so future maintenance branches inherit it.

All four backported commits carry `cherry picked from` trailers pointing to their main counterparts.