### PR TITLE
fix(registry): harden digest-path status mapping

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,7 @@ skipAnnotations: []
 routing:
   activeCheck:
     timeout: 1s
+    resolveDigest: false
     staleMirrorCleanup:
       maxConcurrent: 10
       timeout: 5s
@@ -45,6 +46,7 @@ monitoring:
       method: HEAD
       interval: 3h
       maxPerInterval: 25
+      resolveDigest: false
       # timeout: 0          (no per-check timeout)
       # fallbackCredentialSecret:
       #   namespace: ...
@@ -165,7 +167,7 @@ Controls the rate at which `ClusterImageSetAvailability` checks reach upstream r
 | --- | --- | --- | --- |
 | `method` | string | `HEAD` | HTTP method for the availability probe. `HEAD` or `GET`. |
 | `interval` | duration | `3h` | Time window over which `maxPerInterval` checks are spread for that registry. |
-| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each check makes two requests. |
+| `maxPerInterval` | int | `25` | Maximum number of image checks per `interval` for the registry. When `resolveDigest` is enabled, each tag-reference check makes two requests (digest references still make one). |
 | `timeout` | duration | `0` (no timeout) | Deadline per individual check. |
 | `resolveDigest` | bool | unset (disabled) | Same digest check as `routing.activeCheck.resolveDigest`, applied to monitoring probes. An `items` entry leaving it unset inherits the `default` value; setting it to `false` opts that registry out. See [Stale tag caches on pull-through proxies](./guides/troubleshooting.md#stale-tag-caches-on-pull-through-proxies). |
 | `fallbackCredentialSecret` | object | unset | Reference (`name`, `namespace`) to a `kubernetes.io/dockerconfigjson` Secret used when no Pod-level pull secret is available for the image. |

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -11,10 +11,10 @@ By default, the availability check does what a plain `docker pull` of a tag star
 
 In both cases the tag request returns `200`, kuik marks the image `Available`, and the pull fails anyway. Setting `resolveDigest: true` makes kuik follow the same two-step path as the runtime. A `404` on the digest request is reported as `NotFound` with a `tag/digest inconsistency` message, which triggers the usual fallback to the next alternative and the re-mirror path.
 
-The check is opt-in because it **doubles the number of registry requests** for every checked tag. Two things must be adjusted when enabling it:
+The check is opt-in because it **doubles the number of registry requests** for every checked tag reference (references already pinned to a digest still cost a single request). Two things must be adjusted when enabling it:
 
-- **`routing.activeCheck.timeout`** — the two requests share a single timeout envelope, so the total is bounded to `timeout`, not `2 × timeout`. The `1s` default sizes one round-trip; give it at least `2s`–`3s` so both requests fit.
-- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
+- **`routing.activeCheck.timeout`** — the two requests of a tag check share a single timeout envelope, so the total is bounded to `timeout`, not `2 × timeout`. The `1s` default sizes one round-trip; give it at least `2s`–`3s` so both requests fit.
+- **`monitoring.registries.*.maxPerInterval`** — this counts *images checked*, not requests sent. With `resolveDigest`, each tag-referenced image costs two requests, so halve the value on rate-constrained registries (Docker Hub anonymous pulls, for example) to keep the same request budget.
 
 ```yaml
 routing:
@@ -28,13 +28,13 @@ monitoring:
       docker.io:
         resolveDigest: true
         interval: 1h
-        maxPerInterval: 3 # halved from 6, each check now costs two requests
+        maxPerInterval: 3 # halved from 6, each tag check now costs two requests
 ```
 
 `routing.activeCheck.resolveDigest` (webhook) and `monitoring.registries.*.resolveDigest` (`ClusterImageSetAvailability` probes) are independent, enable whichever surface you need. The per-registry value is a three-state boolean: unset inherits `monitoring.registries.default`, `false` opts a single registry out of an enabled default.
 
 > [!NOTE]
-> Registries that answer `405` or `501` to a manifest-by-digest request are treated as available. They support tag lookup but not the digest path for that HTTP method, and serve the image fine to container runtimes.
+> Registries that answer `405` or `501` to a **HEAD** manifest-by-digest request are treated as available: HEAD support on the digest path is optional for proxies, and they still serve the image fine to container runtimes. The same answer to a **GET** probe is reported as unreachable, since runtimes pull with GET.
 
 ## Duplicated credential secrets (`kuik-kuik-...`)
 

--- a/internal/controller/kuik/registryconfig_test.go
+++ b/internal/controller/kuik/registryconfig_test.go
@@ -1,0 +1,88 @@
+package kuik
+
+import (
+	"testing"
+	"time"
+
+	"github.com/enix/kube-image-keeper/internal/config"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// The per-registry resolveDigest override is a three-state boolean: an items
+// entry leaving it unset (nil) inherits the default, an explicit false opts a
+// single registry out of an enabled default, an explicit true opts it in.
+func TestRegistryConfigResolveDigest(t *testing.T) {
+	tests := []struct {
+		name        string
+		defaultFlag *bool
+		override    *config.RegistryMonitoring
+		want        bool
+	}{
+		{
+			name: "no override, unset default is disabled",
+		},
+		{
+			name:        "no override inherits enabled default",
+			defaultFlag: boolPtr(true),
+			want:        true,
+		},
+		{
+			name:        "unset override inherits enabled default",
+			defaultFlag: boolPtr(true),
+			override:    &config.RegistryMonitoring{},
+			want:        true,
+		},
+		{
+			name:        "explicit false overrides enabled default",
+			defaultFlag: boolPtr(true),
+			override:    &config.RegistryMonitoring{ResolveDigest: boolPtr(false)},
+			want:        false,
+		},
+		{
+			name:     "explicit true overrides unset default",
+			override: &config.RegistryMonitoring{ResolveDigest: boolPtr(true)},
+			want:     true,
+		},
+		{
+			name:        "explicit true overrides disabled default",
+			defaultFlag: boolPtr(false),
+			override:    &config.RegistryMonitoring{ResolveDigest: boolPtr(true)},
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registries := config.Registries{
+				Default: config.RegistryMonitoring{
+					Method:         "HEAD",
+					Interval:       3 * time.Hour,
+					MaxPerInterval: 25,
+					ResolveDigest:  tt.defaultFlag,
+				},
+				Items: map[string]config.RegistryMonitoring{},
+			}
+			if tt.override != nil {
+				registries.Items["registry.example.com"] = *tt.override
+			}
+
+			r := &ClusterImageSetAvailabilityReconciler{
+				Config: &config.Config{
+					Monitoring: config.Monitoring{Registries: registries},
+				},
+			}
+
+			merged := r.registryConfig("registry.example.com")
+			if got := merged.ResolveDigestEnabled(); got != tt.want {
+				t.Errorf("ResolveDigestEnabled() = %v, want %v (default=%v, override=%+v)", got, tt.want, tt.defaultFlag, tt.override)
+			}
+
+			// The merge must not clobber unrelated defaults when the override
+			// only sets resolveDigest.
+			if merged.Method != "HEAD" || merged.MaxPerInterval != 25 {
+				t.Errorf("merge clobbered unrelated defaults: %+v", merged)
+			}
+		})
+	}
+}

--- a/internal/registry/availability.go
+++ b/internal/registry/availability.go
@@ -98,9 +98,14 @@ func checkDigestPath(ctx context.Context, client *Client, method string, referen
 		case http.StatusNotFound:
 			return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("tag/digest inconsistency: %q resolves to digest %s but the registry does not serve that manifest: %w", reference, desc.Digest.String(), err)
 		case http.StatusMethodNotAllowed, http.StatusNotImplemented:
-			// The registry supports tag lookup but not manifest-by-digest for this
-			// HTTP method; the tag check already passed so the image is pullable.
-			return kuikv1alpha1.ImageAvailabilityAvailable, nil
+			// Some proxies support tag lookup but not manifest-by-digest over
+			// HEAD, while still serving GET-by-digest fine to container runtimes
+			// (HEAD support is optional in the distribution spec). Only give the
+			// benefit of the doubt to HEAD probes: runtimes pull with GET, so a
+			// registry rejecting GET-by-digest cannot serve the image.
+			if method == http.MethodHead {
+				return kuikv1alpha1.ImageAvailabilityAvailable, nil
+			}
 		}
 		return availabilityFromError(err)
 	}
@@ -112,6 +117,11 @@ func checkDigestPath(ctx context.Context, client *Client, method string, referen
 // status, wrapping the underlying cause.
 func availabilityFromError(err error) (kuikv1alpha1.ImageAvailabilityStatus, error) {
 	switch TransportStatusCode(err) {
+	case http.StatusTooManyRequests:
+		// Some registries send 429 without RateLimit-* headers, so IsRateLimited
+		// does not catch them; the status code alone must map to QuotaExceeded
+		// for the monitoring scheduler to apply its back-off.
+		return kuikv1alpha1.ImageAvailabilityQuotaExceeded, fmt.Errorf("rate limit exceeded: %w", err)
 	case http.StatusNotFound:
 		return kuikv1alpha1.ImageAvailabilityNotFound, fmt.Errorf("image not found: %w", err)
 	case http.StatusUnauthorized, http.StatusForbidden:

--- a/internal/registry/availability_test.go
+++ b/internal/registry/availability_test.go
@@ -20,11 +20,12 @@ import (
 type digestResponseMode int
 
 const (
-	digestResponseNormal           digestResponseMode = iota // pass through to the real registry
-	digestResponseNotFound                                   // 404 — stale tag cache / blocked by policy
-	digestResponseRateLimit                                  // 429 with RateLimit-Remaining: 0 header
-	digestResponseUnauthorized                               // 401 — fine-grained auth on digest path
-	digestResponseMethodNotAllowed                           // 405 — proxy supports tags but not digest lookup
+	digestResponseNormal             digestResponseMode = iota // pass through to the real registry
+	digestResponseNotFound                                     // 404 — stale tag cache / blocked by policy
+	digestResponseRateLimit                                    // 429 with RateLimit-Remaining: 0 header
+	digestResponseUnauthorized                                 // 401 — fine-grained auth on digest path
+	digestResponseMethodNotAllowed                             // 405 — proxy supports tags but not digest lookup
+	digestResponseRateLimitNoHeaders                           // 429 without RateLimit-* headers
 )
 
 // brokenDigestRegistry wraps an in-memory registry and can intercept manifest-by-digest
@@ -57,6 +58,9 @@ func (b *brokenDigestRegistry) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				return
 			case digestResponseMethodNotAllowed:
 				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			case digestResponseRateLimitNoHeaders:
+				w.WriteHeader(http.StatusTooManyRequests)
 				return
 			}
 		}
@@ -175,12 +179,32 @@ func TestCheckImageAvailabilityResolveDigest(t *testing.T) {
 			wantReads:     2,
 		},
 		{
-			name:          "digest method not allowed returns Available",
+			name:          "digest method not allowed over HEAD returns Available",
 			reference:     tagReference,
 			method:        http.MethodHead,
 			digestMode:    digestResponseMethodNotAllowed,
 			resolveDigest: true,
 			want:          kuikv1alpha1.ImageAvailabilityAvailable,
+			wantReads:     2,
+		},
+		{
+			name:          "digest method not allowed over GET is not pullable",
+			reference:     tagReference,
+			method:        http.MethodGet,
+			digestMode:    digestResponseMethodNotAllowed,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityUnreachable,
+			wantErr:       "registry unreachable",
+			wantReads:     2,
+		},
+		{
+			name:          "headerless rate limit on digest path returns QuotaExceeded",
+			reference:     tagReference,
+			method:        http.MethodHead,
+			digestMode:    digestResponseRateLimitNoHeaders,
+			resolveDigest: true,
+			want:          kuikv1alpha1.ImageAvailabilityQuotaExceeded,
+			wantErr:       "rate limit exceeded",
 			wantReads:     2,
 		},
 	}


### PR DESCRIPTION
Follow-ups from the CodeRabbit review on #651, applied to main where the same code landed via #613:

- **405/501 on manifest-by-digest is only forgiven for HEAD probes**: HEAD support on the digest path is optional for proxies, but runtimes pull with GET, so a registry rejecting GET-by-digest cannot serve the image and now maps through `availabilityFromError`.
- **Headerless 429 responses map to `QuotaExceeded`**: registries that rate-limit without `RateLimit-*` headers previously fell through to `Unreachable`, bypassing the monitoring scheduler back-off.
- Docs: the full configuration example now lists the `resolveDigest` keys, request accounting is qualified as tag-only, and the 405/501 note reflects the HEAD/GET distinction.
- Tests: GET+405 and headerless-429 regression cases, plus coverage of the per-registry `resolveDigest` three-state merge (inherit / opt-out / opt-in).

Counterpart of the equivalent commits on #651 (2.3.x).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for disabling digest resolution.
  - Clarified request limits for tag-based and digest-pinned references.

- **Bug Fixes**
  - Improved registry availability handling for HEAD and GET responses.
  - Correctly identifies HTTP 429 responses as quota exceeded, even without rate-limit headers.

- **Documentation**
  - Expanded configuration and troubleshooting guidance for digest resolution, timeouts, and registry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->