### PR TITLE
fix(helm): restrict the manager to Linux nodes by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,8 @@ Each entry supports the following fields:
 
 The list must contain at least one entry with a non-empty `architecture`; the operator refuses to start otherwise.
 
+An empty `os` also means Windows manifests are mirrored by default; see [hybrid Linux/Windows clusters](./installation.md#hybrid-linuxwindows-clusters) before narrowing this list.
+
 > [!WARNING]
 > Changing this list after images have been mirrored does not re-mirror or delete previously copied manifests; the new platform set only applies to subsequent mirror operations.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,3 +23,48 @@ kubectl create secret docker-registry my-registry-secret --docker-server=my-regi
 ```
 
 If you let kuik cleanup expired images in your registry, you still have to configure garbage collection on your own as kuik only delete images reference.
+
+## Hybrid Linux/Windows clusters
+
+kuik is shipped as a Linux-only image, so the chart restricts the manager to Linux nodes by default:
+
+```yaml
+manager:
+  nodeSelector:
+    kubernetes.io/os: linux
+```
+
+Without this constraint, the scheduler is free to place the manager on a Windows node of a hybrid cluster, where it fails with `ImagePullBackOff`.
+
+Helm merges maps, so adding your own keys keeps the constraint:
+
+```yaml
+manager:
+  nodeSelector:
+    node.kubernetes.io/instance-type: m5.large # scheduled on Linux m5.large nodes
+```
+
+Should you need to lift it entirely, set the key to `null`:
+
+```yaml
+manager:
+  nodeSelector:
+    kubernetes.io/os: null
+```
+
+> [!NOTE]
+> No default `tolerations` are set: since the manager never lands on a Windows node, taints commonly applied to those nodes (such as `os=windows:NoSchedule`) are irrelevant. Add `manager.tolerations` if your Linux nodes carry taints of their own.
+
+Routing and mirroring themselves are OS-agnostic: kuik rewrites images for Windows pods like any other, and the default [`mirroring.platforms`](./configuration.md#mirroringplatforms) (`[{architecture: amd64}]`, with `os` unset) matches any operating system, so `windows/amd64` manifests are mirrored out of the box.
+
+Beware that setting `mirroring.platforms` **replaces** that default. Restricting it to Linux breaks the mirroring of Windows images: the copy fails with a no-matching-platform error, and pods fall back to their original image. On a cluster running both, list both:
+
+```yaml
+configuration:
+  mirroring:
+    platforms:
+      - os: linux
+        architecture: amd64
+      - os: windows
+        architecture: amd64
+```

--- a/helm/kube-image-keeper/values.yaml
+++ b/helm/kube-image-keeper/values.yaml
@@ -22,8 +22,11 @@ manager:
   podSecurityContext: {}
   # -- Security context for containers of the manager pod
   securityContext: {}
-  # -- Node selector for the manager pod
-  nodeSelector: {}
+  # -- Node selector for the manager pod. Defaults to Linux nodes only, as the
+  # manager is shipped as a Linux-only image and must not be scheduled on Windows
+  # nodes of hybrid clusters.
+  nodeSelector:
+    kubernetes.io/os: linux
   # -- Toleration for the manager pod
   tolerations: []
   # -- Deployment strategy for the manager pod


### PR DESCRIPTION
## Problem

The manager is shipped as a Linux-only image, yet the chart set no scheduling
constraint (`manager.nodeSelector` defaulted to `{}`, with no default affinity
either). On hybrid Linux/Windows clusters the scheduler is free to place the
manager pod on a Windows node, where it fails with `ImagePullBackOff` — forcing
operators to patch the deployment after every install or upgrade.

Fixes #630.

## Change

- `manager.nodeSelector` now defaults to `kubernetes.io/os: linux`. No template
  change was needed: `manager-deployment.yaml` already renders `nodeSelector`
  through a `with` block.
- Docs: a new *Hybrid Linux/Windows clusters* section in `docs/installation.md`,
  cross-referenced from `mirroring.platforms` in `docs/configuration.md`.

Helm merges maps, so a user adding their own keys keeps the constraint, and it
can still be lifted explicitly:

```yaml
manager:
  nodeSelector:
    kubernetes.io/os: null
```

`kubernetes.io/os` is a well-known label set by the kubelet since Kubernetes
1.14, so this cannot make the pod unschedulable on an existing cluster.
No default `tolerations` are added: since the manager never lands on a Windows
node, taints commonly applied to those nodes (`os=windows:NoSchedule`) are moot.

## Notes on the Windows-image part of the issue

No code change was needed there. The default `mirroring.platforms` is
`[{architecture: amd64}]` with `os` unset, and an unset field is a wildcard, so
`windows/amd64` manifests are already mirrored out of the box. The actual trap
is the reverse: narrowing the list to `os: linux` makes the copy of a Windows
image fail with a no-matching-platform error, and pods fall back to their
original image. That is now documented, with a both-OSes example.

## Out of scope

`config/manager/manager.yaml` (the kustomize path used by `make deploy` and the
e2e suite) still carries only the commented-out Kubebuilder `nodeAffinity`
scaffold, so it remains affected by the same problem. Happy to align it here or
in a follow-up.

The chart has no test harness today (CI runs Go lint/test and the chart build,
but no rendering assertions), so this PR adds none. A `helm unittest` spec
covering the default, the merge with a user-supplied key, and the `null`
override would be a good first one — say the word and I will add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The manager now defaults to running on Linux nodes, helping ensure compatibility with Linux-only images.
  - Improved support guidance for hybrid Linux/Windows Kubernetes clusters, including node selectors, tolerations, Helm configuration, and platform-specific image mirroring.

- **Documentation**
  - Clarified that an empty platform configuration matches Windows manifests.
  - Added guidance for configuring image mirroring in hybrid clusters, with links to related setup information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
