### PR TITLE
chore: make the release configuration line-local for the 2.3 line

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,21 @@ jobs:
             print("Nothing should be published, skipping...")
             sys.exit(1)
 
+      # Maintenance-line branches (X.Y.x-stable, X.Y.x-rc) are regular release
+      # branches for semantic-release, so nothing caps their computed version
+      # natively; a stray feat or breaking-change commit on the line would
+      # otherwise escape it (e.g. publish a 2.4.0 from the 2.3 line).
+      - name: Enforce the maintenance line version range
+        if: contains(github.ref_name, '.x-')
+        env:
+          NEXT_VERSION: ${{ steps.dry-run.outputs.new_release_version }}
+        run: |
+          line="${GITHUB_REF_NAME%.x-*}"
+          if [[ "${NEXT_VERSION}" != "${line}."* ]]; then
+            echo "::error::Version ${NEXT_VERSION} escapes the ${line}.x maintenance line; check for feat or breaking-change commits on the branch."
+            exit 1
+          fi
+
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yaml

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,16 +31,11 @@
     ]
   ],
   "branches": [
-    "+([0-9])?(.{+([0-9]),x}).x",
     {
-      "name": "main",
-      "prerelease": "beta"
+      "name": "2.3.x-stable"
     },
     {
-      "name": "release"
-    },
-    {
-      "name": "2.3.0-rc",
+      "name": "2.3.x-rc",
       "prerelease": "rc"
     }
   ]


### PR DESCRIPTION
Part of the per-line release configuration rework (counterpart PR on main: #655).

semantic-release reads `.releaserc.json` from the branch it runs on, so each release line carries its own branches configuration. For the 2.3 line:

- `2.3.x-stable`: publishes the line's stable releases (fast-forwarded to the head of `2.3.x` at release time). As a regular release branch it is immediately usable, unlike a maintenance-typed branch whose range collapsed when releasing v2.3.1.
- `2.3.x-rc`: line-wide release-candidate branch, replacing the per-version rc branches (next candidate computes as v2.3.2-rc.1, no config edit per release).
- Since regular release branches have no native version cap, the Release workflow now fails when the computed version escapes `2.3.*` (stray `feat` or breaking-change commit on the line).

The `main`, `release`, maintenance-glob and `2.3.0-rc` entries served no purpose in a config that other lines never read. Full process documentation lands in CONTRIBUTING.md via #655.