### PR TITLE
chore: per-line release configuration and process documentation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,21 @@ jobs:
             print("Nothing should be published, skipping...")
             sys.exit(1)
 
+      # Maintenance-line branches (X.Y.x-stable, X.Y.x-rc) are regular release
+      # branches for semantic-release, so nothing caps their computed version
+      # natively; a stray feat or breaking-change commit on the line would
+      # otherwise escape it (e.g. publish a 2.4.0 from the 2.3 line).
+      - name: Enforce the maintenance line version range
+        if: contains(github.ref_name, '.x-')
+        env:
+          NEXT_VERSION: ${{ steps.dry-run.outputs.new_release_version }}
+        run: |
+          line="${GITHUB_REF_NAME%.x-*}"
+          if [[ "${NEXT_VERSION}" != "${line}."* ]]; then
+            echo "::error::Version ${NEXT_VERSION} escapes the ${line}.x maintenance line; check for feat or breaking-change commits on the branch."
+            exit 1
+          fi
+
   lint:
     name: Lint
     uses: ./.github/workflows/lint.yaml

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -31,7 +31,6 @@
     ]
   ],
   "branches": [
-    "+([0-9])?(.{+([0-9]),x}).x",
     {
       "name": "main",
       "prerelease": "beta"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,9 +75,31 @@ The following rules apply:
 
 kube-image-keeper is licensed under the [MIT License](./LICENSE). By contributing to this project, you agree to license your contributions under the same license.
 
+## Releases
+
+Releases are cut manually by dispatching the [Release workflow](./.github/workflows/release.yaml) on the branch to publish. semantic-release computes the version from the conventional commits since the last release, and reads its configuration from the dispatched branch's [`.releaserc.json`](./.releaserc.json): each release line therefore carries its own branches configuration (`main` and `release` for the main line; `X.Y.x-stable` and `X.Y.x-rc` for a maintenance line).
+
+### Channels
+
+- **beta** (from `main`): development pre-releases of the next major or minor version. The scope is still moving; breaking changes may occur between betas.
+- **rc** (from `X.Y.x-rc`): frozen release candidates for a patch of the `X.Y` line, published for validation (for example on a pre-production cluster) before the stable release. Only a release blocker justifies cutting an rc.2.
+- **stable** (from `release` for the main line, from `X.Y.x-stable` for a maintenance line): production releases.
+
+### Releasing the main line
+
+- Beta: dispatch the Release workflow on `main`.
+- Stable: fast-forward `release` to the commit to publish, then dispatch the workflow on `release`. The `release` branch follows `main`'s lineage and is protected against force pushes and deletion: it only moves forward.
+
+### Releasing a maintenance line `X.Y`
+
+- Release candidate: fast-forward `X.Y.x-rc` to the head of `X.Y.x`, then dispatch the workflow on `X.Y.x-rc`.
+- Stable: fast-forward `X.Y.x-stable` to the head of `X.Y.x`, then dispatch the workflow on `X.Y.x-stable`.
+
+A maintenance line only ships fixes. `X.Y.x-stable` and `X.Y.x-rc` are regular release branches for semantic-release, so nothing caps their computed version natively; the Release workflow enforces the line instead, and fails when the computed version escapes `X.Y.*` (which would mean a stray `feat` or breaking-change commit landed on the line).
+
 ## Cutting a maintenance branch
 
-Each release line `X.Y` is maintained from a **maintenance branch `X.Y.x`**: semantic-release publishes maintenance releases from it (see the `branches` glob in [`.releaserc.json`](./.releaserc.json)), and it carries both the release-line code and its published documentation. When cutting a new line `X.Y`:
+Each release line `X.Y` is maintained from a **maintenance branch `X.Y.x`**: it carries the release-line code and its published documentation, and receives the line's fixes through pull requests. When cutting a new line `X.Y`:
 
 1. Create the branch from the release tag and push it:
 
@@ -86,6 +108,21 @@ Each release line `X.Y` is maintained from a **maintenance branch `X.Y.x`**: sem
    git push -u origin X.Y.x
    ```
 
-2. Retarget the maintenance-branch Dependabot entries: in [`.github/dependabot.yml`](./.github/dependabot.yml) (on `main`), update the `target-branch` of the patch-only `gomod` and `docker` entries to `X.Y.x`, and drop entries for release lines that reached end of life. These entries keep the release line's dependencies patched (security fixes almost always ship as patch releases), and their `fix` commit prefix makes semantic-release cut a patch release when they are merged.
+2. Make the release configuration line-local: on `X.Y.x`, trim the `branches` of [`.releaserc.json`](./.releaserc.json) down to `X.Y.x-stable` and `X.Y.x-rc` (with `"prerelease": "rc"`), as described in [Releases](#releases), then commit and push (the Release workflow reads the file from the branch it is dispatched on):
 
-3. Publish the version's documentation on the website: see [Add a new archived version](./website/README.md#add-a-new-archived-version).
+   ```bash
+   git commit -m "chore: make the release configuration line-local" .releaserc.json
+   git push
+   ```
+
+3. Create the line's publishing branches from that commit, so both carry the line-local configuration (if they were created earlier, fast-forward them onto it instead):
+
+   ```bash
+   git branch X.Y.x-stable X.Y.x
+   git branch X.Y.x-rc X.Y.x
+   git push -u origin X.Y.x-stable X.Y.x-rc
+   ```
+
+4. Retarget the maintenance-branch Dependabot entries: in [`.github/dependabot.yml`](./.github/dependabot.yml) (on `main`), update the `target-branch` of the patch-only `gomod` and `docker` entries to `X.Y.x`, and drop entries for release lines that reached end of life. These entries keep the release line's dependencies patched (security fixes almost always ship as patch releases), and their `fix` commit prefix makes a later release dispatch cut a patch release.
+
+5. Publish the version's documentation on the website: see [Add a new archived version](./website/README.md#add-a-new-archived-version).


### PR DESCRIPTION
Counterpart of #654 for the main line.

- `.releaserc.json` on main only declares `main` (beta channel) and `release`: the maintenance glob was never read by main-line releases (semantic-release loads its configuration from the branch it runs on), and it is what collapsed the `2.3.x` range when releasing v2.3.1 (`>=2.3.0 <2.3.0`).
- CONTRIBUTING.md gains a **Releases** section: channel vocabulary (beta = moving development pre-releases from main; rc = frozen candidates from `X.Y.x-rc`; stable = production), the release procedure for each line including the interim regime while a line is still the latest, and the rationale for protecting `release` against force pushes (a maintenance line must not escape its version range by repositioning `release`). The maintenance-branch cutting procedure now includes creating `X.Y.x-rc` and committing the line-local config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for beta, release-candidate, and stable release channels.
  - Clarified procedures for main-line and maintenance-line releases.
  - Documented branch protection, versioning behavior, dependency updates, and release documentation steps.
  - Updated maintenance-branch instructions for release-candidate preparation.

- **Chores**
  - Simplified the semantic-release branch configuration by removing an additional branch pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->